### PR TITLE
Speed control bugfixes

### DIFF
--- a/ALT-Scann8-UserInterface.py
+++ b/ALT-Scann8-UserInterface.py
@@ -776,7 +776,7 @@ def min_frame_steps_spinbox_dbl_click(event):
     FrameSteps_auto = not FrameSteps_auto
     SessionData["FrameStepsAuto"] = FrameSteps_auto
     if FrameSteps_auto:
-        min_frame_steps_spinbox.config(state=DISABLED)
+        min_frame_steps_spinbox.config(state='readonly')
     else:
         min_frame_steps_spinbox.config(state=NORMAL)
     send_arduino_command(CMD_SET_MIN_FRAME_STEPS, 0 if FrameSteps_auto else MinFrameSteps)
@@ -826,7 +826,7 @@ def pt_level_spinbox_dbl_click(event):
     PTLevel_auto = not PTLevel_auto
     SessionData["PTLevelAuto"] = PTLevel_auto
     if PTLevel_auto:
-        pt_level_spinbox.config(state=DISABLED)
+        pt_level_spinbox.config(state='readonly')
     else:
         pt_level_spinbox.config(state=NORMAL)
     send_arduino_command(CMD_SET_PT_LEVEL, 0 if PTLevel_auto else PTLevel)


### PR DESCRIPTION
- UI: When in automated mode, set spinboxes for PTLevel and Steps/Frame as 'readonly' instead of 'disabled', for better visibility

- Controller
  - Adapt film collect speed when increasing scan speed (will need further refinement)
  - Even when not set as automated, automatic steps/frame value was still calculated and applied
  - During the speed reduction when about to detect a frame, sometimes a very wrong value was produced. Generate an error in such case to stop the scanning process (until issue is identified)