### PR TITLE
I2c cleanup

### DIFF
--- a/ALT-Scann8-UserInterface.py
+++ b/ALT-Scann8-UserInterface.py
@@ -257,9 +257,10 @@ def send_arduino_command(cmd, param=12345):
     global SimulatedRun, ALT_Scann8_controller_detected
 
     if not SimulatedRun:
-        #i2c.write_byte_data(16, cmd, 0)  # Send command to Arduino
+        time.sleep(0.0001)  #wait 100 µs, to avoid I/O errors
         i2c.write_i2c_block_data(16, cmd, [int(param%256), int(param/256)])  # Send command to Arduino
         logging.debug("Sending command %i to Arduino", cmd)
+        time.sleep(0.0001)  #wait 100 µs, same
 
 
 def exit_app():  # Exit Application
@@ -2323,7 +2324,7 @@ def load_session_data():
                     PTLevel_auto = SessionData["PTLevelAuto"]
                     pt_level_str.set(str(PTLevel))
                     if PTLevel_auto:
-                        pt_level_spinbox.config(state=DISABLED)
+                        pt_level_spinbox.config(state='readonly')
                         send_arduino_command(CMD_SET_PT_LEVEL, 0)
                     else:
                         pt_level_spinbox.config(fg='black', state=NORMAL)
@@ -2332,7 +2333,7 @@ def load_session_data():
                     FrameSteps_auto = SessionData["FrameStepsAuto"]
                     min_frame_steps_str.set(str(MinFrameSteps))
                     if FrameSteps_auto:
-                        min_frame_steps_spinbox.config(state=DISABLED)
+                        min_frame_steps_spinbox.config(state='readonly')
                         send_arduino_command(CMD_SET_MIN_FRAME_STEPS, 0)
                     else:
                         min_frame_steps_spinbox.config(fg='black', state=NORMAL)


### PR DESCRIPTION
It seems the big part of the I2C cleanup code was somehow delivered to master while I tried to merge latest changes in master (ScanSpeed bugfixes) in I2C_Cleanup branch. It seems changes were done in both directions (for now, not missing anything). So, what is being merged here are some final changes in the I2C cleanup code, plus some bugfixes (some unrelated to I2C):
- While automatic mode enabled, spinboxes for Steps/Frame and PT Level are set as 'readonly' instead of disabled (better legibility)
- On RPi UI, add delays of 100µs before and after sending data to Arduino to avoid (or minimize at least) I/O errors (collisions might happen due to the asynchronous nature of the communication between both)
- Revert max speed delay to 500 µs (250 µs is too fast)
- No need to set MinFrameStps to 100 when starting scan process, ro running a single step
- Consolidate report to RPi of automatic levels in a single call (RSP_REPORT_AUTO_LEVELS)
- Change Frame detection condition (in IsHoleDetected) to be more flexible. It is a bit counter intuitive, but in practice seems to work better (have to find the reason why).