### PR TITLE
I2C cleanup

### DIFF
--- a/ALT-Scann8-Pico-Controller.c
+++ b/ALT-Scann8-Pico-Controller.c
@@ -52,38 +52,38 @@ int MaxDebugRepetitions = 3;
 boolean GreenLedOn = false;  
 int UI_Command; // Stores I2C command from Raspberry PI --- ScanFilm=10 / UnlockReels mode=20 / Slow Forward movie=30 / One step frame=40 / Rewind movie=60 / Fast Forward movie=61 / Set Perf Level=90
 // I2C commands (RPi to Arduino): Constant definition
-#define CMD_UI_VERSION_ID 1
-#define CMD_UI_START_SCAN 10
-#define CMD_UI_TERMINATE 11
-#define CMD_UI_GET_NEXT_FRAME 12
-#define CMD_UI_SET_REGULAR_8 18
-#define CMD_UI_SET_SUPER_8 19
-#define CMD_UI_SWITCH_REEL_LOCK_STATUS 20
-#define CMD_UI_FILM_FORWARD 30
-#define CMD_UI_SINGLE_STEP 40
-#define CMD_UI_ADVANCE_FRAME 41
-#define CMD_UI_ADVANCE_FRAME_FRACTION 42
-#define CMD_UI_SET_PT_LEVEL 50
-#define CMD_UI_SET_MIN_FRAME_STEPS 52
-#define CMD_UI_SET_FRAME_FINE_TUNE 54
-#define CMD_UI_REWIND 60
-#define CMD_UI_FAST_FORWARD 61
-#define CMD_UI_INCREASE_WIND_SPEED 62
-#define CMD_UI_DECREASE_WIND_SPEED 63
-#define CMD_UI_UNCONDITIONAL_REWIND 64
-#define CMD_UI_UNCONDITIONAL_FAST_FORWARD 65
-#define CMD_UI_SET_SCAN_SPEED 70
-#define CMD_UI_ASYNC_ACK 255
+#define CMD_VERSION_ID 1
+#define CMD_GET_CNT_STATUS 2
+#define CMD_START_SCAN 10
+#define CMD_TERMINATE 11
+#define CMD_GET_NEXT_FRAME 12
+#define CMD_SET_REGULAR_8 18
+#define CMD_SET_SUPER_8 19
+#define CMD_SWITCH_REEL_LOCK_STATUS 20
+#define CMD_FILM_FORWARD 30
+#define CMD_SINGLE_STEP 40
+#define CMD_ADVANCE_FRAME 41
+#define CMD_ADVANCE_FRAME_FRACTION 42
+#define CMD_SET_PT_LEVEL 50
+#define CMD_SET_MIN_FRAME_STEPS 52
+#define CMD_SET_FRAME_FINE_TUNE 54
+#define CMD_REWIND 60
+#define CMD_FAST_FORWARD 61
+#define CMD_INCREASE_WIND_SPEED 62
+#define CMD_DECREASE_WIND_SPEED 63
+#define CMD_UNCONDITIONAL_REWIND 64
+#define CMD_UNCONDITIONAL_FAST_FORWARD 65
+#define CMD_SET_SCAN_SPEED 70
 // I2C responses (Arduino to RPi): Constant definition
-#define CMD_CNT_VERSION_ID 1
-#define CMD_CNT_FORCE_INIT 2
-#define CMD_CNT_FRAME_AVAILABLE 80
-#define CMD_CNT_SCAN_ERROR 81
-#define CMD_CNT_REWIND_ERROR 82
-#define CMD_CNT_FAST_FORWARD_ERROR 83
-#define CMD_CNT_REWIND_ENDED 84
-#define CMD_CNT_FAST_FORWARD_ENDED 85
-#define CMD_CNT_REPORT_AUTO_LEVELS 86
+#define RSP_VERSION_ID 1
+#define RSP_FORCE_INIT 2
+#define RSP_FRAME_AVAILABLE 80
+#define RSP_SCAN_ERROR 81
+#define RSP_REWIND_ERROR 82
+#define RSP_FAST_FORWARD_ERROR 83
+#define RSP_REWIND_ENDED 84
+#define RSP_FAST_FORWARD_ENDED 85
+#define RSP_REPORT_AUTO_LEVELS 86
 
 
 // Immutable values
@@ -196,25 +196,20 @@ void CollectOutgoingFilm(bool);
 
 // JRE - Support data variables
 #define QUEUE_SIZE 20
-volatile struct {
+typedef struct Queue {
     int Data[QUEUE_SIZE];
     int Param[QUEUE_SIZE];
+    int Param2[QUEUE_SIZE];
     int in;
     int out;
-} CommandQueue;
+};
 
-void SendToRPi(byte cmd, int param1, int param2, int param3, int param4)
+volatile Queue CommandQueue;
+volatile Queue ResponseQueue;
+
+void SendToRPi(byte rsp, int param1, int param2)
 {
-    BufferForRPi[0] = cmd;
-    BufferForRPi[1] = param1/256;
-    BufferForRPi[2] = param1%256;
-    BufferForRPi[3] = param2/256;
-    BufferForRPi[4] = param2%256;
-    BufferForRPi[5] = param3/256;
-    BufferForRPi[6] = param3%256;
-    BufferForRPi[7] = param4/256;
-    BufferForRPi[8] = param4%256;
-    digitalWrite(13, HIGH);
+    push_rsp(rsp, param1, param2);
 }
 
 
@@ -246,6 +241,9 @@ void setup() {
     // Initialize I2C slave for I2C0 (comm with RPi). Init queue pointers before defining callback
     CommandQueue.in = 0;
     CommandQueue.out = 0;
+    ResponseQueue.in = 0;
+    ResponseQueue.out = 0;
+
     i2c_slave_init (i2c0, 0x33, receiveEvent);    // Init pico as I2C slave, set callback for receive events
 
     // Assign function to pins
@@ -324,11 +322,11 @@ void setup() {
 void loop() {
     int param;
 
-    SendToRPi(CMD_CNT_FORCE_INIT, 0, 0, 0, 0);  // Request UI to resend init sequence, in case controller reloaded while UI active
+    SendToRPi(RSP_FORCE_INIT, 0, 0);  // Request UI to resend init sequence, in case controller reloaded while UI active
 
     while (1) {
-        if (dataInQueue())
-            UI_Command = pop(&param);   // Get next command from queue if one exists
+        if (dataInCmdQueue())
+            UI_Command = pop_cmd(&param);   // Get next command from queue if one exists
         else
             UI_Command = 0;
 
@@ -337,7 +335,7 @@ void loop() {
         ReportPlotterInfo();    // Regular report of plotter info
 
         switch (UI_Command) {
-            case CMD_UI_SET_PT_LEVEL:
+            case CMD_SET_PT_LEVEL:
                 DebugPrint(">PTLevel", param);
                 if (param >= 0 && param <= 900) {
                     if (param == 0)
@@ -350,7 +348,7 @@ void loop() {
                     DebugPrint(">PTLevel",param);
                 }
                 break;
-            case CMD_UI_SET_MIN_FRAME_STEPS:
+            case CMD_SET_MIN_FRAME_STEPS:
                 DebugPrint(">MinFSteps", param);
                 if (param == 0 || param >= 100 && param <= 600) {
                     if (param == 0)
@@ -367,32 +365,29 @@ void loop() {
                     }
                 }
                 break;
-            case CMD_UI_SET_FRAME_FINE_TUNE:
+            case CMD_SET_FRAME_FINE_TUNE:
                 DebugPrint(">FineT", param);
                 PerforationThresholdAutoLevelRatio = 40 + param;    // Change threshold ratio
                 if (param > 0)  // Also to move up we add extra steps
                     FrameFineTune = param;
                 break;
-            case CMD_UI_SET_SCAN_SPEED:
+            case CMD_SET_SCAN_SPEED:
                 DebugPrint(">Speed", param);
                 ScanSpeed = BaseScanSpeed + (10-param) * StepScanSpeed;
                 if (ScanSpeed < OriginalScanSpeed && collect_modulo > 0)  // Increase film collection frequency if increasing scan speed
                     collect_modulo--;
                 OriginalScanSpeed = ScanSpeed;
                 break;
-            case CMD_UI_ASYNC_ACK:
-                SendToRPi(0, 0, 0, 0, 0);  // Clear previous callback on RPi
-                break;
         }
 
         switch (ScanState) {
             case Sts_Idle:
                 switch (UI_Command) {
-                    case CMD_UI_VERSION_ID:
+                    case CMD_VERSION_ID:
                         DebugPrintStr(">V_ID");
-                        SendToRPi(CMD_CNT_VERSION_ID, 2, 0, 0, 0);  // 1 - Arduino, 2 - RPi Pico
+                        SendToRPi(RSP_VERSION_ID, 2, 0);  // 1 - Arduino, 2 - RPi Pico
                         break;
-                    case CMD_UI_START_SCAN:
+                    case CMD_START_SCAN:
                         DebugPrintStr(">Scan");
                         ScanState = Sts_Scan;
                         pwm_set_gpio_level (PIN_UV_LED, UVLedBrightness);   // Need to check if this maps to Arduino (see next commented line)
@@ -404,13 +399,13 @@ void loop() {
                         collect_modulo = 10;
                         //tone(A2, 2000, 50);   // No tone in pico, to be checked
                         break;
-                    case CMD_UI_TERMINATE:  //Exit app
+                    case CMD_TERMINATE:  //Exit app
                         if (UVLedOn) {
                             pwm_set_gpio_level (PIN_UV_LED, UVLedBrightness);   // Need to check if this maps to Arduino (see next commented line)
                             UVLedOn = false;
                         }
                         break;
-                    case CMD_UI_GET_NEXT_FRAME:  // Continue scan to next frame
+                    case CMD_GET_NEXT_FRAME:  // Continue scan to next frame
                         ScanState = Sts_Scan;
                         StartFrameTime = get_absolute_time();
                         ScanSpeed = OriginalScanSpeed;
@@ -419,9 +414,9 @@ void loop() {
                         // Also send, if required, to RPi autocalculated threshold level every frame
                         // Alternate reports for each value, otherwise I2C has I/O errors
                         if (PT_Level_Auto || Frame_Steps_Auto)
-                            SendToRPi(CMD_CNT_REPORT_AUTO_LEVELS, PerforationThresholdLevel, MinFrameSteps, 0, 0);
+                            SendToRPi(RSP_REPORT_AUTO_LEVELS, PerforationThresholdLevel, MinFrameSteps);
                         break;
-                    case CMD_UI_SET_REGULAR_8:  // Select R8 film
+                    case CMD_SET_REGULAR_8:  // Select R8 film
                         DebugPrintStr(">R8");
                         IsS8 = false;
                         MinFrameSteps = MinFrameStepsR8;
@@ -431,7 +426,7 @@ void loop() {
                             PerforationThresholdLevel = PerforationThresholdLevelR8;
                         OriginalPerforationThresholdLevel = PerforationThresholdLevelR8;
                         break;
-                    case CMD_UI_SET_SUPER_8:  // Select S8 film
+                    case CMD_SET_SUPER_8:  // Select S8 film
                         DebugPrintStr(">S8");
                         IsS8 = true;
                         MinFrameSteps = MinFrameStepsS8;
@@ -441,26 +436,25 @@ void loop() {
                             PerforationThresholdLevel = PerforationThresholdLevelS8;
                         OriginalPerforationThresholdLevel = PerforationThresholdLevelS8;
                         break;
-                    case CMD_UI_SWITCH_REEL_LOCK_STATUS:
+                    case CMD_SWITCH_REEL_LOCK_STATUS:
                         ScanState = Sts_UnlockReels;
                         sleep_ms(50);
                         break;
-                    case CMD_UI_FILM_FORWARD:
+                    case CMD_FILM_FORWARD:
                         collect_modulo = 4;
                         ScanState = Sts_SlowForward;
                         sleep_ms(50);
                         break;
-                    case CMD_UI_SINGLE_STEP:
+                    case CMD_SINGLE_STEP:
                         DebugPrintStr(">SStep");
                         ScanState = Sts_SingleStep;
                         sleep_ms(50);
                         break;
-                    case CMD_UI_REWIND: // Rewind
-                    case CMD_UI_UNCONDITIONAL_REWIND: // Rewind unconditional
-                        if (FilmInFilmgate() and UI_Command == CMD_UI_REWIND) { // JRE 13 Aug 22: Cannot rewind, there is film loaded
+                    case CMD_REWIND: // Rewind
+                    case CMD_UNCONDITIONAL_REWIND: // Rewind unconditional
+                        if (FilmInFilmgate() and UI_Command == CMD_REWIND) { // JRE 13 Aug 22: Cannot rewind, there is film loaded
                             DebugPrintStr("Rwnd err");
-                            SendToRPi(CMD_CNT_REWIND_ERROR, 0, 0, 0, 0);
-                            /*
+                            SendToRPi(RSP_REWIND_ERROR, 0, 0);
                             tone(A2, 2000, 100);
                             sleep_ms(150);
                             tone(A2, 1000, 100);
@@ -484,11 +478,11 @@ void loop() {
                         }
                         sleep_ms(50);
                         break;
-                    case CMD_UI_FAST_FORWARD:  // Fast Forward
-                    case CMD_UI_UNCONDITIONAL_FAST_FORWARD:  // Fast Forward unconditional
-                        if (FilmInFilmgate() and UI_Command == CMD_UI_FAST_FORWARD) { // JRE 13 Aug 22: Cannot fast forward, there is film loaded
+                    case CMD_FAST_FORWARD:  // Fast Forward
+                    case CMD_UNCONDITIONAL_FAST_FORWARD:  // Fast Forward unconditional
+                        if (FilmInFilmgate() and UI_Command == CMD_FAST_FORWARD) { // JRE 13 Aug 22: Cannot fast forward, there is film loaded
                             DebugPrintStr("FF err");
-                            SendToRPi(CMD_CNT_FAST_FORWARD_ERROR, 0, 0, 0, 0);
+                            SendToRPi(RSP_FAST_FORWARD_ERROR, 0, 0);
                             /*
                             tone(A2, 2000, 100);
                             sleep_ms(150);
@@ -512,22 +506,22 @@ void loop() {
                             RewindSpeed = 4000;
                         }
                         break;
-                    case CMD_UI_INCREASE_WIND_SPEED:  // Tune Rewind/FF speed delay up, allowing to slow down the rewind/ff speed
+                    case CMD_INCREASE_WIND_SPEED:  // Tune Rewind/FF speed delay up, allowing to slow down the rewind/ff speed
                         if (TargetRewindSpeedLoop < 4000)
                             TargetRewindSpeedLoop += 20;
                         break;
-                    case CMD_UI_DECREASE_WIND_SPEED:  // Tune Rewind/FF speed delay down, allowing to speed up the rewind/ff speed
+                    case CMD_DECREASE_WIND_SPEED:  // Tune Rewind/FF speed delay down, allowing to speed up the rewind/ff speed
                         if (TargetRewindSpeedLoop > 200)
                           TargetRewindSpeedLoop -= 20;
                         break;
-                    case CMD_UI_ADVANCE_FRAME:
+                    case CMD_ADVANCE_FRAME:
                         DebugPrint(">Advance frame", IsS8 ? MinFrameStepsS8 : MinFrameStepsR8);
                         if (IsS8)
                             capstan_advance(MinFrameStepsS8);
                         else
                             capstan_advance(MinFrameStepsR8);
                         break;
-                    case CMD_UI_ADVANCE_FRAME_FRACTION:
+                    case CMD_ADVANCE_FRAME_FRACTION:
                         DebugPrint(">Advance frame", 5);
                         capstan_advance(5);
                         break;
@@ -535,7 +529,7 @@ void loop() {
                 break;
             case Sts_Scan:
                 CollectOutgoingFilm(false);
-                if (UI_Command == CMD_UI_START_SCAN) {
+                if (UI_Command == CMD_START_SCAN) {
                     DebugPrintStr("-Scan");
                     ScanState = Sts_Idle; // Exit scan loop
                 }
@@ -549,7 +543,7 @@ void loop() {
                 }
                 break;
             case Sts_UnlockReels:
-                if (UI_Command == CMD_UI_SWITCH_REEL_LOCK_STATUS) { //request to lock reels again
+                if (UI_Command == CMD_SWITCH_REEL_LOCK_STATUS) { //request to lock reels again
                     ReelsUnlocked = false;
                     gpio_put(PIN_MOTOR_B_NEUTRAL,0);
                     gpio_put(PIN_MOTOR_C_NEUTRAL,0);
@@ -583,7 +577,7 @@ void loop() {
                 }
                 break;
             case Sts_SlowForward:
-                if (UI_Command == CMD_UI_FILM_FORWARD) { // Stop slow forward
+                if (UI_Command == CMD_FILM_FORWARD) { // Stop slow forward
                     sleep_ms(50);
                     ScanState = Sts_Idle;
                 }
@@ -606,7 +600,7 @@ boolean RewindFilm(int UI_Command) {
   
     //Wire.begin(16);
 
-    if (UI_Command == CMD_UI_REWIND) {
+    if (UI_Command == CMD_REWIND) {
         stopping = true;
     }
     else if (stopping) {
@@ -623,7 +617,7 @@ boolean RewindFilm(int UI_Command) {
             gpio_put(PIN_MOTOR_B_NEUTRAL,0);
             gpio_put(PIN_MOTOR_C_NEUTRAL,0);
             sleep_ms(100);
-            SendToRPi(CMD_CNT_REWIND_ENDED, 0, 0, 0, 0);
+            SendToRPi(RSP_REWIND_ENDED, 0, 0, 0, 0);
         }
     }
     else {
@@ -644,7 +638,7 @@ boolean FastForwardFilm(int UI_Command) {
 
   //Wire.begin(16);  // join I2c bus with address #16
 
-    if (UI_Command == CMD_UI_FAST_FORWARD) {
+    if (UI_Command == CMD_FAST_FORWARD) {
         stopping = true;
     }
     else if (stopping) {
@@ -661,7 +655,7 @@ boolean FastForwardFilm(int UI_Command) {
             gpio_put(PIN_MOTOR_B_NEUTRAL,0);
             gpio_put(PIN_MOTOR_C_NEUTRAL,0);
             sleep_ms(100);
-            SendToRPi(CMD_CNT_FAST_FORWARD_ENDED, 0, 0, 0, 0);
+            SendToRPi(RSP_FAST_FORWARD_ENDED, 0, 0, 0, 0);
         }
     }
     else {
@@ -886,7 +880,7 @@ ScanResult scan(int UI_Command) {
         FrameDetected = false;
 
         //-------------ScanFilm-----------
-        if (UI_Command == CMD_UI_START_SCAN) {   // UI Requesting to end current scan
+        if (UI_Command == CMD_START_SCAN) {   // UI Requesting to end current scan
             retvalue = SCAN_TERMINATION_REQUESTED;
             FrameDetected = false;
             //DecreaseSpeedFrameSteps = 260; // JRE 20/08/2022 - Disabled, added option to set manually from UI
@@ -921,7 +915,7 @@ ScanResult scan(int UI_Command) {
                 //tone(A2, 2000, 35);
             }
             else {
-                SendToRPi(CMD_CNT_FRAME_AVAILABLE, 0, 0, 0, 0);
+                SendToRPi(RSP_FRAME_AVAILABLE, 0, 0, 0, 0);
             }
       
             FrameDetected = false;
@@ -934,7 +928,7 @@ ScanResult scan(int UI_Command) {
         else if (FrameStepsDone > 2*DecreaseSpeedFrameSteps) {
             retvalue = SCAN_FRAME_DETECTION_ERROR;
             // Tell UI (Raspberry PI) an error happened during scanning
-            SendToRPi(CMD_CNT_SCAN_ERROR, FrameStepsDone, 2*DecreaseSpeedFrameSteps, 0, 0);
+            SendToRPi(RSP_SCAN_ERROR, FrameStepsDone, 2*DecreaseSpeedFrameSteps);
             FrameStepsDone = 0;
         }
         return (retvalue);
@@ -965,34 +959,54 @@ void sendEvent() {
   Wire.write(BufferForRPi,9);
 }
 
-boolean push(int IncomingIc, int param) {
+boolean push(Queue * queue, int IncomingIc, int param, int param2) {
     boolean retvalue = false;
-    if ((CommandQueue.in+1) % QUEUE_SIZE != CommandQueue.out) {
-        CommandQueue.Data[CommandQueue.in] = IncomingIc;
-        CommandQueue.Param[CommandQueue.in] = param;
-        CommandQueue.in++;
-        CommandQueue.in %= QUEUE_SIZE;
+    if ((queue -> in+1) % QUEUE_SIZE != queue -> out) {
+        queue -> Data[queue -> in] = IncomingIc;
+        queue -> Param[queue -> in] = param;
+        queue -> Param2[queue -> in] = param2;
+        queue -> in++;
+        queue -> in %= QUEUE_SIZE;
         retvalue = true;
     }
     // else: Queue full: Should not happen. Not sure how this should be handled
     return(retvalue);
 }
 
-int pop(int * param) {
+int pop(Queue * queue, int * param, int * param2) {
     int retvalue = -1;  // default return value: -1 (error)
-    if (CommandQueue.out != CommandQueue.in) {
-        retvalue = CommandQueue.Data[CommandQueue.out];
+    if (queue -> out != queue -> in) {
+        retvalue = queue -> Data[queue -> out];
         if (param != NULL)
-            *param =  CommandQueue.Param[CommandQueue.out];
-        CommandQueue.out++;
-        CommandQueue.out %= QUEUE_SIZE;
+            *param =  queue -> Param[queue -> out];
+        if (param2 != NULL)
+            *param2 =  queue -> Param2[queue -> out];
+        queue -> out++;
+        queue -> out %= QUEUE_SIZE;
     }
     // else: Queue empty: Nothing to do
     return(retvalue);
 }
 
-boolean dataInQueue(void) {
+boolean push_cmd(int cmd, int param) {
+    push(&CommandQueue, cmd, param, 0);
+}
+int pop_cmd(int * param) {
+    return(pop(&CommandQueue, param, NULL));
+}
+boolean push_rsp(int rsp, int param, int param2) {
+    push(&ResponseQueue, rsp, param, param2);
+}
+int pop_rsp(int * param, int * param2) {
+    return(pop(&ResponseQueue, param, param2));
+}
+
+boolean dataInCmdQueue(void) {
     return (CommandQueue.out != CommandQueue.in);
+}
+
+boolean dataInRspQueue(void) {
+    return (ResponseQueue.out != ResponseQueue.in);
 }
 
 void DebugPrintAux(const char * str, unsigned long i) {

--- a/ALT-Scann8-UserInterface.py
+++ b/ALT-Scann8-UserInterface.py
@@ -155,38 +155,38 @@ FilmHoleY2 = 300
 SharpnessValue = 1
 
 # Commands (RPI to Arduino)
-CMD_UI_VERSION_ID = 1
-CMD_UI_START_SCAN = 10
-CMD_UI_TERMINATE = 11
-CMD_UI_GET_NEXT_FRAME = 12
-CMD_UI_SET_REGULAR_8 = 18
-CMD_UI_SET_SUPER_8 = 19
-CMD_UI_SWITCH_REEL_LOCK_STATUS = 20
-CMD_UI_FILM_FORWARD = 30
-CMD_UI_SINGLE_STEP = 40
-CMD_UI_ADVANCE_FRAME = 41
-CMD_UI_ADVANCE_FRAME_FRACTION = 42
-CMD_UI_SET_PT_LEVEL = 50
-CMD_UI_SET_MIN_FRAME_STEPS = 52
-CMD_UI_SET_FRAME_FINE_TUNE = 54
-CMD_UI_REWIND = 60
-CMD_UI_FAST_FORWARD = 61
-CMD_UI_INCREASE_WIND_SPEED = 62
-CMD_UI_DECREASE_WIND_SPEED = 63
-CMD_UI_UNCONDITIONAL_REWIND = 64
-CMD_UI_UNCONDITIONAL_FAST_FORWARD = 65
-CMD_UI_SET_SCAN_SPEED = 70
-CMD_UI_ASYNC_ACK = 255
+CMD_VERSION_ID = 1
+CMD_GET_CNT_STATUS = 2
+CMD_START_SCAN = 10
+CMD_TERMINATE = 11
+CMD_GET_NEXT_FRAME = 12
+CMD_SET_REGULAR_8 = 18
+CMD_SET_SUPER_8 = 19
+CMD_SWITCH_REEL_LOCK_STATUS = 20
+CMD_FILM_FORWARD = 30
+CMD_SINGLE_STEP = 40
+CMD_ADVANCE_FRAME = 41
+CMD_ADVANCE_FRAME_FRACTION = 42
+CMD_SET_PT_LEVEL = 50
+CMD_SET_MIN_FRAME_STEPS = 52
+CMD_SET_FRAME_FINE_TUNE = 54
+CMD_REWIND = 60
+CMD_FAST_FORWARD = 61
+CMD_INCREASE_WIND_SPEED = 62
+CMD_DECREASE_WIND_SPEED = 63
+CMD_UNCONDITIONAL_REWIND = 64
+CMD_UNCONDITIONAL_FAST_FORWARD = 65
+CMD_SET_SCAN_SPEED = 70
 # Responses (Arduino to RPi)
-CMD_CNT_VERSION_ID = 1
-CMD_CNT_FORCE_INIT = 2
-CMD_CNT_FRAME_AVAILABLE = 80
-CMD_CNT_SCAN_ERROR = 81
-CMD_CNT_REWIND_ERROR = 82
-CMD_CNT_FAST_FORWARD_ERROR = 83
-CMD_CNT_REWIND_ENDED = 84
-CMD_CNT_FAST_FORWARD_ENDED = 85
-CMD_CNT_REPORT_AUTO_LEVELS = 86
+RSP_VERSION_ID = 1
+RSP_FORCE_INIT = 2
+RSP_FRAME_AVAILABLE = 80
+RSP_SCAN_ERROR = 81
+RSP_REWIND_ERROR = 82
+RSP_FAST_FORWARD_ERROR = 83
+RSP_REWIND_ENDED = 84
+RSP_FAST_FORWARD_ENDED = 85
+RSP_REPORT_AUTO_LEVELS = 86
 
 
 # Expert mode variables - By default Exposure and white balance are set as automatic, with adapt delay
@@ -259,22 +259,6 @@ SessionData = {
     "FrameStepsAuto": True
 }
 
-
-def send_arduino_command(cmd, param=12345):
-    global SimulatedRun, ALT_Scann8_controller_detected
-
-    if not SimulatedRun:
-        time.sleep(0.0001)  #wait 100 µs, to avoid I/O errors
-        try:
-            i2c.write_i2c_block_data(16, cmd, [int(param%256), int(param>>8)])  # Send command to Arduino
-        except IOError:
-            logging.warning("Error while sending command %i, param %i to Arduino. Retrying...", cmd, param)
-            time.sleep(0.2)  #wait 100 µs, to avoid I/O errors
-            i2c.write_i2c_block_data(16, cmd, [int(param%256), int(param>>8)])  # Send command to Arduino
-
-        time.sleep(0.0001)  #wait 100 µs, same
-
-
 def exit_app():  # Exit Application
     global win
     global SimulatedRun
@@ -283,7 +267,7 @@ def exit_app():  # Exit Application
 
     # Uncomment next two lines when running on RPi
     if not SimulatedRun:
-        send_arduino_command(CMD_UI_TERMINATE)   # Tell Arduino we stop (to turn off uv led
+        send_arduino_command(CMD_TERMINATE)   # Tell Arduino we stop (to turn off uv led
         # Close preview if required
         if not IsPiCamera2 or PiCam2PreviewEnabled:
             camera.stop_preview()
@@ -309,7 +293,7 @@ def set_free_mode():
         Free_btn.config(text='Unlock Reels', bg=save_bg, fg=save_fg, relief=RAISED)
 
     if not SimulatedRun:
-        send_arduino_command(CMD_UI_SWITCH_REEL_LOCK_STATUS)
+        send_arduino_command(CMD_SWITCH_REEL_LOCK_STATUS)
 
     FreeWheelActive = not FreeWheelActive
 
@@ -656,7 +640,7 @@ def wb_spinbox_dbl_click(event):
     global colour_gains_red_value_label, colour_gains_blue_value_label
 
     if not ExpertMode:
-        return ()
+        return
 
     CurrentAwbAuto = not CurrentAwbAuto
     SessionData["CurrentAwbAuto"] = str(CurrentAwbAuto)
@@ -716,7 +700,7 @@ def manual_scan_advance_frame_fraction():
     if not ExpertMode:
         return
     if not SimulatedRun:
-        send_arduino_command(CMD_UI_ADVANCE_FRAME_FRACTION)
+        send_arduino_command(CMD_ADVANCE_FRAME_FRACTION)
         time.sleep(0.2)
         capture('preview')
         time.sleep(0.2)
@@ -729,7 +713,7 @@ def manual_scan_take_snap():
     if not SimulatedRun:
         capture('manual')
         time.sleep(0.2)
-        send_arduino_command(CMD_UI_ADVANCE_FRAME)
+        send_arduino_command(CMD_ADVANCE_FRAME)
         time.sleep(0.2)
         capture('preview')
         time.sleep(0.2)
@@ -812,7 +796,7 @@ def rwnd_speed_down():
     global rwnd_speed_control_delay
 
     if not SimulatedRun:
-        send_arduino_command(CMD_UI_INCREASE_WIND_SPEED)
+        send_arduino_command(CMD_INCREASE_WIND_SPEED)
     if rwnd_speed_delay + rwnd_speed_delay*0.1 < 4000:
         rwnd_speed_delay += rwnd_speed_delay*0.1
     else:
@@ -824,7 +808,7 @@ def rwnd_speed_up():
     global rwnd_speed_control_delay
 
     if not SimulatedRun:
-        send_arduino_command(CMD_UI_DECREASE_WIND_SPEED)
+        send_arduino_command(CMD_DECREASE_WIND_SPEED)
     if rwnd_speed_delay -rwnd_speed_delay*0.1 > 200:
         rwnd_speed_delay -= rwnd_speed_delay*0.1
     else:
@@ -838,7 +822,7 @@ def min_frame_steps_selection(updown):
     MinFrameSteps = int(min_frame_steps_spinbox.get())
     SessionData["MinFrameSteps"] = MinFrameSteps
     SessionData["MinFrameSteps" + SessionData["FilmType"]] = MinFrameSteps
-    send_arduino_command(CMD_UI_SET_MIN_FRAME_STEPS, MinFrameSteps)
+    send_arduino_command(CMD_SET_MIN_FRAME_STEPS, MinFrameSteps)
 
 
 def min_frame_steps_spinbox_focus_out(event):
@@ -848,7 +832,7 @@ def min_frame_steps_spinbox_focus_out(event):
     SessionData["MinFrameSteps"] = MinFrameSteps
     SessionData["MinFrameSteps" + SessionData["FilmType"]] = MinFrameSteps
     if not FrameSteps_auto: # Not sure we can have a focus out event for a disabled control, but just in case
-        send_arduino_command(CMD_UI_SET_MIN_FRAME_STEPS, MinFrameSteps)
+        send_arduino_command(CMD_SET_MIN_FRAME_STEPS, MinFrameSteps)
 
 
 def min_frame_steps_spinbox_dbl_click(event):
@@ -861,7 +845,7 @@ def min_frame_steps_spinbox_dbl_click(event):
         min_frame_steps_spinbox.config(state='readonly')
     else:
         min_frame_steps_spinbox.config(state=NORMAL)
-    send_arduino_command(CMD_UI_SET_MIN_FRAME_STEPS, 0 if FrameSteps_auto else MinFrameSteps)
+    send_arduino_command(CMD_SET_MIN_FRAME_STEPS, 0 if FrameSteps_auto else MinFrameSteps)
 
 
 def frame_fine_tune_selection(updown):
@@ -870,7 +854,7 @@ def frame_fine_tune_selection(updown):
     FrameFineTune = int(frame_fine_tune_spinbox.get())
     SessionData["FrameFineTune"] = FrameFineTune
     SessionData["FrameFineTune" + SessionData["FilmType"]] = FrameFineTune
-    send_arduino_command(CMD_UI_SET_FRAME_FINE_TUNE, FrameFineTune)
+    send_arduino_command(CMD_SET_FRAME_FINE_TUNE, FrameFineTune)
 
 
 def frame_fine_tune_spinbox_focus_out(event):
@@ -879,7 +863,7 @@ def frame_fine_tune_spinbox_focus_out(event):
     FrameFineTune = int(frame_fine_tune_spinbox.get())
     SessionData["FrameFineTune"] = FrameFineTune
     SessionData["FrameFineTune" + SessionData["FilmType"]] = FrameFineTune
-    send_arduino_command(CMD_UI_SET_FRAME_FINE_TUNE, FrameFineTune)
+    send_arduino_command(CMD_SET_FRAME_FINE_TUNE, FrameFineTune)
 
 
 def pt_level_selection(updown):
@@ -888,7 +872,7 @@ def pt_level_selection(updown):
     PTLevel = int(pt_level_spinbox.get())
     SessionData["PTLevel"] = PTLevel
     SessionData["PTLevel" + SessionData["FilmType"]] = PTLevel
-    send_arduino_command(CMD_UI_SET_PT_LEVEL, PTLevel)
+    send_arduino_command(CMD_SET_PT_LEVEL, PTLevel)
 
 
 def pt_level_spinbox_focus_out(event):
@@ -898,7 +882,7 @@ def pt_level_spinbox_focus_out(event):
     SessionData["PTLevel"] = PTLevel
     SessionData["PTLevel" + SessionData["FilmType"]] = PTLevel
     if not PTLevel_auto: # Not sure we can have a focus out event for a disabled control, but just in case
-        send_arduino_command(CMD_UI_SET_PT_LEVEL, PTLevel)
+        send_arduino_command(CMD_SET_PT_LEVEL, PTLevel)
 
 
 def pt_level_spinbox_dbl_click(event):
@@ -911,7 +895,7 @@ def pt_level_spinbox_dbl_click(event):
         pt_level_spinbox.config(state='readonly')
     else:
         pt_level_spinbox.config(state=NORMAL)
-    send_arduino_command(CMD_UI_SET_PT_LEVEL, 0 if PTLevel_auto else PTLevel)
+    send_arduino_command(CMD_SET_PT_LEVEL, 0 if PTLevel_auto else PTLevel)
 
 
 def scan_speed_selection(updown):
@@ -919,7 +903,7 @@ def scan_speed_selection(updown):
     global ScanSpeed
     ScanSpeed = int(scan_speed_spinbox.get())
     SessionData["ScanSpeed"] = ScanSpeed
-    send_arduino_command(CMD_UI_SET_SCAN_SPEED, ScanSpeed)
+    send_arduino_command(CMD_SET_SCAN_SPEED, ScanSpeed)
 
 
 def scan_speed_spinbox_focus_out(event):
@@ -927,7 +911,7 @@ def scan_speed_spinbox_focus_out(event):
     global ScanSpeed
     ScanSpeed = int(scan_speed_spinbox.get())
     SessionData["ScanSpeed"] = ScanSpeed
-    send_arduino_command(CMD_UI_SET_SCAN_SPEED, ScanSpeed)
+    send_arduino_command(CMD_SET_SCAN_SPEED, ScanSpeed)
 
 
 def button_status_change_except(except_button, active):
@@ -997,7 +981,7 @@ def advance_movie():
     AdvanceMovieActive = not AdvanceMovieActive
     # Send instruction to Arduino
     if not SimulatedRun:
-        send_arduino_command(CMD_UI_FILM_FORWARD)
+        send_arduino_command(CMD_FILM_FORWARD)
 
     # Enable/Disable related buttons
     button_status_change_except(AdvanceMovie_btn, AdvanceMovieActive)
@@ -1039,7 +1023,7 @@ def rewind_movie():
         if confirm:
             time.sleep(0.2)
             if not SimulatedRun:
-                send_arduino_command(CMD_UI_UNCONDITIONAL_REWIND)    # Forced rewind, no filmgate check
+                send_arduino_command(CMD_UNCONDITIONAL_REWIND)    # Forced rewind, no filmgate check
                 # Invoke fast_forward_loop a first time when fast-forward starts
                 win.after(5, rewind_loop)
         else:
@@ -1055,7 +1039,7 @@ def rewind_movie():
     if not RewindErrorOutstanding and not RewindEndOutstanding:  # invoked from button
         time.sleep(0.2)
         if not SimulatedRun:
-            send_arduino_command(CMD_UI_REWIND)
+            send_arduino_command(CMD_REWIND)
 
     if RewindErrorOutstanding:
         RewindErrorOutstanding = False
@@ -1114,7 +1098,7 @@ def fast_forward_movie():
         if confirm:
             time.sleep(0.2)
             if not SimulatedRun:
-                send_arduino_command(CMD_UI_UNCONDITIONAL_FAST_FORWARD)    # Forced FF, no filmgate check
+                send_arduino_command(CMD_UNCONDITIONAL_FAST_FORWARD)    # Forced FF, no filmgate check
                 # Invoke fast_forward_loop a first time when fast-forward starts
                 win.after(5, fast_forward_loop)
         else:
@@ -1130,7 +1114,7 @@ def fast_forward_movie():
     if not FastForwardErrorOutstanding and not FastForwardEndOutstanding:  # invoked from button
         time.sleep(0.2)
         if not SimulatedRun:
-            send_arduino_command(CMD_UI_FAST_FORWARD)
+            send_arduino_command(CMD_FAST_FORWARD)
 
     if FastForwardErrorOutstanding:
         FastForwardErrorOutstanding = False
@@ -1236,7 +1220,7 @@ def single_step_movie():
     global camera
 
     if not SimulatedRun:
-        send_arduino_command(CMD_UI_SINGLE_STEP)
+        send_arduino_command(CMD_SINGLE_STEP)
 
         if IsPiCamera2:
             # If no camera preview, capture frame in memory and display it
@@ -1397,9 +1381,9 @@ def set_s8():
     film_hole_frame_1.place(x=4, y=FilmHoleY2, height=140)
     film_hole_frame_2.place(x=4, y=FilmHoleY2, height=140)
     if not SimulatedRun:
-        send_arduino_command(CMD_UI_SET_SUPER_8)
-        send_arduino_command(CMD_UI_SET_PT_LEVEL, 0 if PTLevel_auto else PTLevel)
-        send_arduino_command(CMD_UI_SET_MIN_FRAME_STEPS, 0 if FrameSteps_auto else MinFrameSteps)
+        send_arduino_command(CMD_SET_SUPER_8)
+        send_arduino_command(CMD_SET_PT_LEVEL, 0 if PTLevel_auto else PTLevel)
+        send_arduino_command(CMD_SET_MIN_FRAME_STEPS, 0 if FrameSteps_auto else MinFrameSteps)
 
 
 
@@ -1428,9 +1412,9 @@ def set_r8():
     film_hole_frame_1.place(x=4, y=FilmHoleY1, height=100)
     film_hole_frame_2.place(x=4, y=FilmHoleY2, height=130)
     if not SimulatedRun:
-        send_arduino_command(CMD_UI_SET_REGULAR_8)
-        send_arduino_command(CMD_UI_SET_PT_LEVEL, 0 if PTLevel_auto else PTLevel)
-        send_arduino_command(CMD_UI_SET_MIN_FRAME_STEPS, 0 if FrameSteps_auto else MinFrameSteps)
+        send_arduino_command(CMD_SET_REGULAR_8)
+        send_arduino_command(CMD_SET_PT_LEVEL, 0 if PTLevel_auto else PTLevel)
+        send_arduino_command(CMD_SET_MIN_FRAME_STEPS, 0 if FrameSteps_auto else MinFrameSteps)
 
 
 
@@ -1522,7 +1506,7 @@ def capture(mode):
     global VideoCaptureActive
 
     if SimulatedRun:
-        return()
+        return
 
     os.chdir(CurrentDir)
 
@@ -1834,7 +1818,7 @@ def start_scan():
 
         # Send command to Arduino to stop/start scan (as applicable, Arduino keeps its own status)
         if not SimulatedRun:
-            send_arduino_command(CMD_UI_START_SCAN)
+            send_arduino_command(CMD_START_SCAN)
 
         # Invoke capture_loop a first time shen scan starts
         win.after(5, capture_loop)
@@ -1900,7 +1884,7 @@ def capture_loop():
                     # Set NewFrameAvailable to False here, to avoid overwriting new frame from arduino
                     NewFrameAvailable = False
                     logging.debug("Frame %i captured.", CurrentFrame)
-                    send_arduino_command(CMD_UI_GET_NEXT_FRAME)  # Tell Arduino to move to next frame
+                    send_arduino_command(CMD_GET_NEXT_FRAME)  # Tell Arduino to move to next frame
                 except IOError:
                     CurrentFrame -= 1
                     NewFrameAvailable = True  # Set NewFrameAvailable to True to repeat next time
@@ -1974,6 +1958,22 @@ def temperature_loop():  # Update RPi temperature every 10 seconds
     win.after(1000, temperature_loop)
 
 
+# send_arduino_command: No response expected
+def send_arduino_command(cmd, param=0):
+    global SimulatedRun, ALT_Scann8_controller_detected
+
+    if not SimulatedRun:
+        time.sleep(0.0001)  #wait 100 µs, to avoid I/O errors
+        try:
+            i2c.write_i2c_block_data(16, cmd, [int(param % 256), int(param >> 8)])  # Send command to Arduino
+        except IOError:
+            logging.warning("Error while sending command %i (param %i) to Arduino. Retrying...", cmd, param)
+            time.sleep(0.2)  #wait 100 µs, to avoid I/O errors
+            i2c.write_i2c_block_data(16, cmd, [int(param%256), int(param>>8)])  # Send command to Arduino
+
+        time.sleep(0.0001)  #wait 100 µs, same
+
+
 def arduino_listen_loop():  # Waits for Arduino communicated events and dispatches accordingly
     global NewFrameAvailable
     global RewindErrorOutstanding, RewindEndOutstanding
@@ -1989,12 +1989,10 @@ def arduino_listen_loop():  # Waits for Arduino communicated events and dispatch
 
     if not SimulatedRun:
         try:
-            ArduinoData = i2c.read_i2c_block_data(16, 0, 9)
+            ArduinoData = i2c.read_i2c_block_data(16, CMD_GET_CNT_STATUS, 5)
             ArduinoTrigger = ArduinoData[0]
             ArduinoParam1 = ArduinoData[1] * 256 + ArduinoData[2]
             ArduinoParam2 = ArduinoData[3] * 256 + ArduinoData[4]
-            ArduinoParam3 = ArduinoData[5] * 256 + ArduinoData[6]
-            ArduinoParam4 = ArduinoData[7] * 256 + ArduinoData[8]
         except IOError:
             ArduinoTrigger = 0
             # Log error to console
@@ -2014,35 +2012,35 @@ def arduino_listen_loop():  # Waits for Arduino communicated events and dispatch
 
     if ArduinoTrigger == 0:  # Do nothing
         pass
-    elif ArduinoTrigger == CMD_CNT_VERSION_ID:  # New Frame available
+    elif ArduinoTrigger == RSP_VERSION_ID:  # New Frame available
         Controller_Id = ArduinoParam1
         if Controller_Id == 1:
             logging.info("Arduino controller detected")
         elif Controller_Id == 2:
             logging.info("Raspberry Pi Pico controller detected")
-    elif ArduinoTrigger == CMD_CNT_FORCE_INIT:  # Controller reloaded, sent init sequence again
+    elif ArduinoTrigger == RSP_FORCE_INIT:  # Controller reloaded, sent init sequence again
         logging.info("Controller requested to reinit")
         reinit_controller()
-    elif ArduinoTrigger == CMD_CNT_FRAME_AVAILABLE:  # New Frame available
+    elif ArduinoTrigger == RSP_FRAME_AVAILABLE:  # New Frame available
         NewFrameAvailable = True
-    elif ArduinoTrigger == CMD_CNT_SCAN_ERROR:  # Error during scan
-        logging.warning("Received scan error from Arduino (%i, %i, %i, %i)", ArduinoParam1, ArduinoParam2, ArduinoParam3, ArduinoParam4)
+    elif ArduinoTrigger == RSP_SCAN_ERROR:  # Error during scan
+        logging.warning("Received scan error from Arduino (%i, %i)", ArduinoParam1, ArduinoParam2)
         ScanProcessError = True
-    elif ArduinoTrigger == CMD_CNT_REPORT_AUTO_LEVELS:  # Get auto levels from Arduino, to be displayed in UI, if auto on
+    elif ArduinoTrigger == RSP_REPORT_AUTO_LEVELS:  # Get auto levels from Arduino, to be displayed in UI, if auto on
         if (PTLevel_auto):
             pt_level_str.set(str(ArduinoParam1))
         if (FrameSteps_auto):
             min_frame_steps_str.set(str(ArduinoParam2))
-    elif ArduinoTrigger == CMD_CNT_REWIND_ENDED:  # Rewind ended, we can re-enable buttons
+    elif ArduinoTrigger == RSP_REWIND_ENDED:  # Rewind ended, we can re-enable buttons
         RewindEndOutstanding = True
         logging.info("Received rewind end event from Arduino")
-    elif ArduinoTrigger == CMD_CNT_FAST_FORWARD_ENDED:  # FastForward ended, we can re-enable buttons
+    elif ArduinoTrigger == RSP_FAST_FORWARD_ENDED:  # FastForward ended, we can re-enable buttons
         FastForwardEndOutstanding = True
         logging.info("Received fast forward end event from Arduino")
-    elif ArduinoTrigger == CMD_CNT_REWIND_ERROR:  # Error during Rewind
+    elif ArduinoTrigger == RSP_REWIND_ERROR:  # Error during Rewind
         RewindErrorOutstanding = True
         logging.warning("Received rewind error from Arduino")
-    elif ArduinoTrigger == CMD_CNT_FAST_FORWARD_ERROR:  # Error during FastForward
+    elif ArduinoTrigger == RSP_FAST_FORWARD_ERROR:  # Error during FastForward
         FastForwardErrorOutstanding = True
         logging.warning("Received fast forward error from Arduino")
     else:
@@ -2050,13 +2048,8 @@ def arduino_listen_loop():  # Waits for Arduino communicated events and dispatch
 
     if ArduinoTrigger != 0:
         ArduinoTrigger = 0
-        try:
-            send_arduino_command(CMD_UI_ASYNC_ACK, 0)  # Ask arduino to send empty buffer to clear previous async report
-        except IOError:
-            # Log error to console
-            logging.debug("Non-critical IOError while clearing async event from Arduino. Will check again.")
 
-    win.after(1, arduino_listen_loop)
+    win.after(10, arduino_listen_loop)
 
 
 def on_form_event(dummy):
@@ -2301,16 +2294,16 @@ def load_session_data():
                 if 'MinFrameSteps' in SessionData:
                     MinFrameSteps = SessionData["MinFrameSteps"]
                     min_frame_steps_str.set(str(MinFrameSteps))
-                    send_arduino_command(CMD_UI_SET_MIN_FRAME_STEPS, MinFrameSteps)
+                    send_arduino_command(CMD_SET_MIN_FRAME_STEPS, MinFrameSteps)
                 if 'FrameStepsAuto' in SessionData:
                     FrameSteps_auto = SessionData["FrameStepsAuto"]
                     min_frame_steps_str.set(str(MinFrameSteps))
                     if FrameSteps_auto:
                         min_frame_steps_spinbox.config(state='readonly')
-                        send_arduino_command(CMD_UI_SET_MIN_FRAME_STEPS, 0)
+                        send_arduino_command(CMD_SET_MIN_FRAME_STEPS, 0)
                     else:
                         min_frame_steps_spinbox.config(fg='black', state=NORMAL)
-                        send_arduino_command(CMD_UI_SET_MIN_FRAME_STEPS, MinFrameSteps)
+                        send_arduino_command(CMD_SET_MIN_FRAME_STEPS, MinFrameSteps)
                 if 'MinFrameStepsS8' in SessionData:
                     MinFrameStepsS8 = SessionData["MinFrameStepsS8"]
                 if 'MinFrameStepsR8' in SessionData:
@@ -2318,21 +2311,21 @@ def load_session_data():
                 if 'FrameFineTune' in SessionData:
                     FrameFineTune = SessionData["FrameFineTune"]
                     frame_fine_tune_str.set(str(FrameFineTune))
-                    send_arduino_command(CMD_UI_SET_FRAME_FINE_TUNE, FrameFineTune)
+                    send_arduino_command(CMD_SET_FRAME_FINE_TUNE, FrameFineTune)
                 if 'PTLevelAuto' in SessionData:
                     PTLevel_auto = SessionData["PTLevelAuto"]
                     pt_level_str.set(str(PTLevel))
                     if PTLevel_auto:
                         pt_level_spinbox.config(state='readonly')
-                        send_arduino_command(CMD_UI_SET_PT_LEVEL, 0)
+                        send_arduino_command(CMD_SET_PT_LEVEL, 0)
                     else:
                         pt_level_spinbox.config(fg='black', state=NORMAL)
-                        send_arduino_command(CMD_UI_SET_PT_LEVEL, PTLevel)
+                        send_arduino_command(CMD_SET_PT_LEVEL, PTLevel)
                 if 'PTLevel' in SessionData:
                     PTLevel = SessionData["PTLevel"]
                     if not PTLevel_auto:
                         pt_level_str.set(str(PTLevel))
-                        send_arduino_command(CMD_UI_SET_PT_LEVEL, PTLevel)
+                        send_arduino_command(CMD_SET_PT_LEVEL, PTLevel)
                 if 'PTLevelS8' in SessionData:
                     PTLevelS8 = SessionData["PTLevelS8"]
                 if 'PTLevelR8' in SessionData:
@@ -2340,7 +2333,7 @@ def load_session_data():
                 if 'ScanSpeed' in SessionData:
                     ScanSpeed = SessionData["ScanSpeed"]
                     scan_speed_str.set(str(ScanSpeed))
-                    send_arduino_command(CMD_UI_SET_SCAN_SPEED, ScanSpeed)
+                    send_arduino_command(CMD_SET_SCAN_SPEED, ScanSpeed)
 
         display_preview()
 
@@ -2351,23 +2344,23 @@ def reinit_controller():
     global FrameFineTune, ScanSpeed
 
     if PTLevel_auto:
-        send_arduino_command(CMD_UI_SET_PT_LEVEL, 0)
+        send_arduino_command(CMD_SET_PT_LEVEL, 0)
     else:
-        send_arduino_command(CMD_UI_SET_PT_LEVEL, PTLevel)
+        send_arduino_command(CMD_SET_PT_LEVEL, PTLevel)
 
     if FrameSteps_auto:
-        send_arduino_command(CMD_UI_SET_MIN_FRAME_STEPS, 0)
+        send_arduino_command(CMD_SET_MIN_FRAME_STEPS, 0)
     else:
-        send_arduino_command(CMD_UI_SET_MIN_FRAME_STEPS, MinFrameSteps)
+        send_arduino_command(CMD_SET_MIN_FRAME_STEPS, MinFrameSteps)
 
     if 'FilmType' in SessionData:
         if SessionData["FilmType"] == "R8":
-            send_arduino_command(CMD_UI_SET_REGULAR_8)
+            send_arduino_command(CMD_SET_REGULAR_8)
         else:
-            send_arduino_command(CMD_UI_SET_SUPER_8)
+            send_arduino_command(CMD_SET_SUPER_8)
 
-    send_arduino_command(CMD_UI_SET_FRAME_FINE_TUNE, FrameFineTune)
-    send_arduino_command(CMD_UI_SET_SCAN_SPEED, ScanSpeed)
+    send_arduino_command(CMD_SET_FRAME_FINE_TUNE, FrameFineTune)
+    send_arduino_command(CMD_SET_SCAN_SPEED, ScanSpeed)
 
 def PiCam2_configure():
     global camera, capture_config, preview_config
@@ -3069,9 +3062,10 @@ def build_ui():
 
 
 def get_controller_version():
+    global Controller_Id
     if Controller_Id == 0:
         logging.debug("Requesting controller version")
-        send_arduino_command(CMD_UI_VERSION_ID)
+        send_arduino_command(CMD_VERSION_ID)
 
 
 def main(argv):


### PR DESCRIPTION
Cleaned up code dealing with I2C communication. No more unsolicited messages from Arduino (slave) to RPi (master). Instead RPi queries Arduino regularly for possible inputs. Also changes back command names to original CMD/RSP naming, as now it makes sense again. Bugfix: Yet another issue with frame fine tune