### PR TITLE
Disk space control + Arduino changes

### DIFF
--- a/ALT-Scann8-Controller.ino
+++ b/ALT-Scann8-Controller.ino
@@ -63,6 +63,7 @@ int UI_Command; // Stores I2C command from Raspberry PI --- ScanFilm=10 / Unlock
 #define CMD_SET_SUPER_8 19
 #define CMD_SWITCH_REEL_LOCK_STATUS 20
 #define CMD_FILM_FORWARD 30
+#define CMD_FILM_BACKWARD 31
 #define CMD_SINGLE_STEP 40
 #define CMD_ADVANCE_FRAME 41
 #define CMD_ADVANCE_FRAME_FRACTION 42
@@ -118,6 +119,7 @@ enum ScanState{
     Sts_Rewind,
     Sts_FastForward,
     Sts_SlowForward,
+    Sts_SlowBackward,
     Sts_SingleStep
 }
 ScanState=Sts_Idle;
@@ -233,8 +235,9 @@ void setup() {
     digitalWrite(MotorA_Neutral, HIGH);
 
     // set direction on stepper motors
-    digitalWrite(MotorA_Direction, LOW);
-    digitalWrite(MotorB_Direction, LOW);
+    digitalWrite(MotorA_Direction, LOW);     // Always counter-clockwise (rewind)
+    digitalWrite(MotorB_Direction, HIGH);    // Normally clockwise (advance to next frame)
+    digitalWrite(MotorC_Direction, HIGH);    // Always clockwise (collect + FF)
 
     digitalWrite(MotorA_Stepper, LOW);
     digitalWrite(MotorB_Stepper, LOW);
@@ -262,6 +265,7 @@ void loop() {
 
         ReportPlotterInfo();    // Regular report of plotter info
 
+        /*
         if (ScanState != Sts_Scan && ScanState != Sts_SingleStep) {
             // Set default state and direction of motors B and C (disabled, clockwise)
             // In the original main loop this was done when UI_Command was NOT Single Step (49). Why???
@@ -270,10 +274,9 @@ void loop() {
             if (UI_Command != CMD_SINGLE_STEP){  // In case we need the exact behavior of original code
                 digitalWrite(MotorB_Stepper, LOW);
                 digitalWrite(MotorC_Stepper, LOW);
-                digitalWrite(MotorC_Direction, HIGH);
-                digitalWrite(MotorB_Direction, HIGH);
             }
         }
+        */
 
         switch (UI_Command) {   // Stateless commands
             case CMD_RESET_CONTROLLER:
@@ -343,6 +346,8 @@ void loop() {
                         break;
                     case CMD_START_SCAN:
                         DebugPrintStr(">Scan");
+                        digitalWrite(MotorC_Neutral, LOW);       // Engage, just in case
+                        digitalWrite(MotorB_Direction, HIGH);    // Set as clockwise, just in case
                         ScanState = Sts_Scan;
                         analogWrite(11, UVLedBrightness); // Turn on UV LED
                         UVLedOn = true;
@@ -400,11 +405,22 @@ void loop() {
                         collect_modulo = 5;
                         collect_timer = 10;
                         ScanState = Sts_SlowForward;
+                        digitalWrite(MotorC_Neutral, LOW);       // Engage, just in case
+                        digitalWrite(MotorB_Direction, HIGH);    // Set as clockwise, just in case
+                        delay(50);
+                        break;
+                    case CMD_FILM_BACKWARD:
+                        collect_modulo = 5;
+                        collect_timer = 10;
+                        ScanState = Sts_SlowBackward;
+                        digitalWrite(MotorC_Neutral, HIGH);     // Disengage, to allow movign back
+                        digitalWrite(MotorB_Direction, LOW);    // Set as anti-clockwise, only for this function
                         delay(50);
                         break;
                     case CMD_SINGLE_STEP:
                         DebugPrintStr(">SStep");
                         ScanState = Sts_SingleStep;
+                        digitalWrite(MotorB_Direction, HIGH);    // Set as clockwise, just in case
                         delay(50);
                         break;
                     case CMD_REWIND: // Rewind
@@ -537,6 +553,16 @@ void loop() {
                 }
                 else {
                     SlowForward();
+                }
+                break;
+            case Sts_SlowBackward:
+                if (UI_Command == CMD_FILM_BACKWARD) { // Stop slow forward
+                    digitalWrite(MotorB_Direction, HIGH);    // Slow backward finished, set as clockwise again
+                    delay(50);
+                    ScanState = Sts_Idle;
+                }
+                else {
+                    SlowBackward();
                 }
                 break;
         }
@@ -702,6 +728,20 @@ void SlowForward(){
     if (CurrentTime > LastMove || LastMove-CurrentTime > 700) { // If timer expired (or wrapped over) ...
         GetLevelPT();   // No need to know PT level here, but used to update plotter data
         CollectOutgoingFilm();
+        digitalWrite(MotorB_Stepper, LOW);
+        digitalWrite(MotorB_Stepper, HIGH);
+        LastMove = CurrentTime + 700;
+    }
+}
+
+void SlowBackward(){
+    static unsigned long LastMove = 0;
+    unsigned long CurrentTime = micros();
+    if (CurrentTime > LastMove || LastMove-CurrentTime > 700) { // If timer expired (or wrapped over) ...
+        GetLevelPT();   // No need to know PT level here, but used to update plotter data
+        // We have no traction sensor on the A reel, so no way to safely implement collect film of that one
+        // Film must be collected manually
+        digitalWrite(MotorB_Stepper, LOW);
         digitalWrite(MotorB_Stepper, HIGH);
         LastMove = CurrentTime + 700;
     }

--- a/ALT-Scann8-UserInterface.py
+++ b/ALT-Scann8-UserInterface.py
@@ -33,7 +33,7 @@ from tkinter import filedialog
 import tkinter.messagebox
 import tkinter.simpledialog
 from tkinter import DISABLED, NORMAL, LEFT, RIGHT, Y, TOP, BOTTOM, N, W, E, NW, X, RAISED, SUNKEN
-from tkinter import Toplevel, Label, Button, Frame, LabelFrame, Canvas
+from tkinter import Label, Button, Frame, LabelFrame, Canvas
 
 from PIL import ImageTk, Image
 

--- a/ALT-Scann8-UserInterface.py
+++ b/ALT-Scann8-UserInterface.py
@@ -19,8 +19,8 @@ __author__ = 'Juan Remirez de Esparza'
 __copyright__ = "Copyright 2022-23, Juan Remirez de Esparza"
 __credits__ = ["Juan Remirez de Esparza"]
 __license__ = "MIT"
-__version__ = "1.8.15"
-__date__ = "2024-01-01"
+__version__ = "1.8.16"
+__date__ = "2024-01-02"
 __version_highlight__ = "Picamera legacy code removal"
 __maintainer__ = "Juan Remirez de Esparza"
 __email__ = "jremirez@hotmail.com"
@@ -47,6 +47,12 @@ import sys
 import getopt
 
 import numpy as np
+
+try:
+    import psutil
+    check_disk_space = True
+except ImportError:
+    check_disk_space = False
 
 try:
     import smbus
@@ -86,6 +92,7 @@ NegativeCaptureActive = False
 HdrCaptureActive = False
 HqCaptureActive = False
 AdvanceMovieActive = False
+RetreatMovieActive = False
 RewindMovieActive = False  # SpolaState in original code from Torulf
 RewindErrorOutstanding = False
 RewindEndOutstanding = False
@@ -165,6 +172,7 @@ CMD_SET_REGULAR_8 = 18
 CMD_SET_SUPER_8 = 19
 CMD_SWITCH_REEL_LOCK_STATUS = 20
 CMD_FILM_FORWARD = 30
+CMD_FILM_BACKWARD = 31
 CMD_SINGLE_STEP = 40
 CMD_ADVANCE_FRAME = 41
 CMD_ADVANCE_FRAME_FRACTION = 42
@@ -1006,7 +1014,7 @@ def hdr_check_bracket_width(event):
 
 
 def button_status_change_except(except_button, active):
-    global Free_btn, SingleStep_btn, Snapshot_btn, AdvanceMovie_btn
+    global Free_btn, SingleStep_btn, Snapshot_btn, AdvanceMovie_btn, RetreatMovie_btn
     global Rewind_btn, FastForward_btn, Start_btn
     global PosNeg_btn, Focus_btn, Start_btn, Exit_btn
     global film_type_S8_btn, film_type_R8_btn
@@ -1028,6 +1036,8 @@ def button_status_change_except(except_button, active):
         Snapshot_btn.config(state=DISABLED if active else NORMAL)
     if except_button != AdvanceMovie_btn:
         AdvanceMovie_btn.config(state=DISABLED if active else NORMAL)
+    if except_button != RetreatMovie_btn:
+        RetreatMovie_btn.config(state=DISABLED if active else NORMAL)
     if except_button != Rewind_btn:
         Rewind_btn.config(state=DISABLED if active else NORMAL)
     if except_button != FastForward_btn:
@@ -1058,6 +1068,7 @@ def advance_movie():
     global AdvanceMovieActive
     global save_bg, save_fg
     global SimulatedRun
+    global AdvanceMovie_btn
 
     # Update button text
     if not AdvanceMovieActive:  # Advance movie is about to start...
@@ -1073,6 +1084,28 @@ def advance_movie():
 
     # Enable/Disable related buttons
     button_status_change_except(AdvanceMovie_btn, AdvanceMovieActive)
+
+
+def retreat_movie():
+    global RetreatMovieActive
+    global save_bg, save_fg
+    global SimulatedRun
+    global RetreatMovie_btn
+
+    # Update button text
+    if not RetreatMovieActive:  # Advance movie is about to start...
+        RetreatMovie_btn.config(text='Stop movie', bg='red',
+                                fg='white', relief=SUNKEN)  # ...so now we propose to stop it in the button test
+    else:
+        RetreatMovie_btn.config(text='Movie backward', bg=save_bg,
+                                fg=save_fg, relief=RAISED)  # Otherwise change to default text to start the action
+    RetreatMovieActive = not RetreatMovieActive
+    # Send instruction to Arduino
+    if not SimulatedRun:
+        send_arduino_command(CMD_FILM_BACKWARD)
+
+    # Enable/Disable related buttons
+    button_status_change_except(RetreatMovie_btn, RetreatMovieActive)
 
 
 def rewind_movie():
@@ -1334,6 +1367,20 @@ def update_rpi_temp():
         RPiTemp = int(int(temp_str) / 100) / 10
     else:
         RPiTemp = 64.5
+
+def disk_space_available():
+    global CurrentDir
+
+    if not check_disk_space:
+        return True
+    disk_usage = psutil.disk_usage(CurrentDir)
+    available_space_mb = disk_usage.free / (1024 ** 2)
+
+    if available_space_mb < 500:
+        logging.debug(f"Disk space running out, only {available_space_mb} MB available")
+        return False
+    else:
+        return True
 
 
 def hdr_set_controls():
@@ -2110,6 +2157,10 @@ def capture_loop():
                 FramesPerMinute = FPM_CalculatedValue
                 Scanned_Images_fpm.config(text=str(int(FPM_CalculatedValue)))
             win.update()
+            if session_frames % 50 == 0 and not disk_space_available():  # Only every 50 frames (500MB buffer exist)
+                logging.error("No disk space available, stopping scan process.")
+                if ScanOngoing:
+                    ScanStopRequested = True  # Stop in next capture loop
         elif ScanProcessError:
             if ScanProcessError_LastTime != 0:
                 if time.time() - ScanProcessError_LastTime <= 5:     # Second error in less than 5 seconds: Stop
@@ -2826,6 +2877,7 @@ def build_ui():
     global hdr_bracket_width_spinbox, hdr_bracket_width_label, hdr_bracket_width_str, hdr_bracket_width
     global hdr_bracket_auto, hdr_bracket_width_auto_checkbox
     global frames_to_go_str, FramesToGo, time_to_go_str
+    global RetreatMovie_btn
 
     # Create a frame to contain the top area (preview + Right buttons) ***************
     top_area_frame = Frame(win, width=850, height=650)
@@ -3338,6 +3390,12 @@ def build_ui():
             manual_scan_take_snap_btn = Button(Manual_scan_btn_frame, text="Snap", width=1, height=1, command=manual_scan_take_snap,
                                      state=DISABLED, font=("Arial", 7))
             manual_scan_take_snap_btn.pack(side=RIGHT, ipadx=5, fill=Y)
+
+            # Retreat movie button (slow backward through filmgate)
+            RetreatMovie_btn = Button(experimental_frame, text="Movie Backward", width=14, height=1, command=retreat_movie,
+                                      activebackground='#f0f0f0', wraplength=80, relief=RAISED, font=("Arial", 7))
+            RetreatMovie_btn.grid(row=3, column=0, columnspan=2, padx=4, pady=4, sticky='')
+
 
 
 def get_controller_version():


### PR DESCRIPTION
- Disk space is now monitored during scan. If less than 500MB remain, scan process stops, to allow doing some cleanup, and prevent app crashing, and losing progress. This brings an additional dependency ('psutil'), that needs to be installed in your PC
- Couple of changes in Arduino
  - Reels are now unlocked by default, they are engage only when needed. 'Unlock reels' is retained for now, but the idea is to remove it since it should not be useful any more
  - New button to perform 'slow backward'. This is only available in experimental mode since it requires manual operation (reel A needs to be moved manually to collect outgoing film). Can be useful in some situations, as I found myself manually moving the capstan back to go back to a frame already passed by