### PR TITLE
ALT-Scann8 1.8.46

### DIFF
--- a/ALT-Scann8-UserInterface.py
+++ b/ALT-Scann8-UserInterface.py
@@ -19,9 +19,9 @@ __author__ = 'Juan Remirez de Esparza'
 __copyright__ = "Copyright 2022-23, Juan Remirez de Esparza"
 __credits__ = ["Juan Remirez de Esparza"]
 __license__ = "MIT"
-__version__ = "1.8.45"
-__date__ = "2024-01-28"
-__version_highlight__ = "UI - Add threshold level to integrated plotter"
+__version__ = "1.8.46"
+__date__ = "2024-02-03"
+__version_highlight__ = "Allow negative Extra Steps (-30-+30)"
 __maintainer__ = "Juan Remirez de Esparza"
 __email__ = "jremirez@hotmail.com"
 __status__ = "Development"
@@ -3500,7 +3500,7 @@ def build_ui():
         frame_extra_steps_spinbox = tk.Spinbox(
             frame_alignment_frame,
             command=(frame_extra_steps_selection_aux, '%d'), width=8,
-            textvariable=frame_extra_steps_str, from_=0, to=20, font=("Arial", FontSize-1))
+            textvariable=frame_extra_steps_str, from_=-30, to=30, font=("Arial", FontSize-1))
         frame_extra_steps_spinbox.grid(row=3, column=1, padx=2, pady=3, sticky=W)
         setup_tooltip(frame_extra_steps_spinbox, "Unconditionally advances the frame n steps after detection. Can be useful only in rare cases, 'Fine tune' should be enough.")
         frame_extra_steps_spinbox.bind("<FocusOut>", frame_extra_steps_spinbox_focus_out)


### PR DESCRIPTION
Arduino 1.0.5
- Extra steps can now be set to negative values (-30 to +30). When negative, they are subtracted from the minimum number of steps where Arduino will start considering the photo-transistor, if positive is still the same, unconditional number os steps are done after frame is detected, before snapshot is taken. Normally negative values shoudl not be needed, but today I had a weird case where even after physically adjusting the film gate position, frames were being detected too high. Need to check the scanner to see if there is something wrong. But then, it was the second movie of the day, and the first went perfectly fine (it had the same characteristics as the one with the problem)