### PR TITLE
ALT-Scann8 1.9.0 (#68)

### DIFF
--- a/ALT-Scann8-Controller.ino
+++ b/ALT-Scann8-Controller.ino
@@ -18,9 +18,9 @@ More info in README.md file
 #define __copyright__   "Copyright 2023, Juan Remirez de Esparza"
 #define __credits__     "Juan Remirez de Esparza"
 #define __license__     "MIT"
-#define __version__     "1.0.2"
-#define  __date__       "2024-01-26"
-#define  __version_highlight__  "Add mandatory margin of 20% to auto PT level"
+#define __version__     "1.0.5"
+#define  __date__       "2024-02-03"
+#define  __version_highlight__  "Allow negative FrameExtraSteps: Deducted from MinFrameSteps on the fly"
 #define __maintainer__  "Juan Remirez de Esparza"
 #define __email__       "jremirez@hotmail.com"
 #define __status__      "Development"
@@ -149,6 +149,7 @@ int MinFrameStepsR8 = R8_HEIGHT/((PI*CapstanDiameter)/(360/(NEMA_STEP_DEGREES/NE
 int MinFrameStepsS8 = S8_HEIGHT/((PI*CapstanDiameter)/(360/(NEMA_STEP_DEGREES/NEMA_MICROSTEPS_IN_STEP)));; // Default value for S8 (286 aprox)
 int MinFrameSteps = MinFrameStepsS8;        // Minimum number of steps to allow frame detection
 int FrameExtraSteps = 0;              // Allow framing adjustment on the fly (manual, automatic would require using CV2 pattern matching, maybe to be checked)
+int FrameDeductSteps = 0;               // Manually force reduction of MinFrameSteps when ExtraFrameSteps is negative
 int DecreaseSpeedFrameStepsBefore = 0;  // 20 - No need to anticipate slow down, the default MinFrameStep should be always less
 int DecreaseSpeedFrameSteps = MinFrameSteps - DecreaseSpeedFrameStepsBefore;    // Steps at which the scanning speed starts to slow down to improve detection
 // ------------------------------------------------------------------------------------------
@@ -334,6 +335,8 @@ void loop() {
                 DebugPrint(">BoostPT", param);
                 if (param >= 1 && param <= 20)  // Also to move up we add extra steps
                     FrameExtraSteps = param;
+                else if (param >= -30 && param <= -1)  // Manually force reduction of MinFrameSteps
+                    FrameDeductSteps = param;
                 break;
             case CMD_SET_SCAN_SPEED:
                 DebugPrint(">Speed", param);
@@ -402,7 +405,7 @@ void loop() {
                         // Also send, if required, to RPi autocalculated threshold level every frame
                         // Alternate reports for each value, otherwise I2C has I/O errors
                         if (PT_Level_Auto || Frame_Steps_Auto)
-                            SendToRPi(RSP_REPORT_AUTO_LEVELS, PerforationThresholdLevel, MinFrameSteps);
+                            SendToRPi(RSP_REPORT_AUTO_LEVELS, PerforationThresholdLevel, MinFrameSteps+FrameDeductSteps);
                         break;
                     case CMD_SET_REGULAR_8:  // Select R8 film
                         DebugPrintStr(">R8");
@@ -433,6 +436,8 @@ void loop() {
                         FilmDetectedTime = millis();
                         NoFilmDetected = false;
                         collect_timer = 10;
+                        analogWrite(11, UVLedBrightness); // Turn on UV LED
+                        UVLedOn = true;
                         ScanState = Sts_SlowForward;
                         digitalWrite(MotorB_Direction, HIGH);    // Set as clockwise, just in case
                         delay(50);
@@ -574,11 +579,15 @@ void loop() {
             case Sts_SlowForward:
                 if (UI_Command == CMD_FILM_FORWARD) { // Stop slow forward
                     delay(50);
+                    analogWrite(11, 0); // Turn off UV LED
+                    UVLedOn = false;
                     ScanState = Sts_Idle;
                     SetReelsAsNeutral(HIGH, HIGH, HIGH);
                 }
                 else {
                     if (!SlowForward()) {
+                        analogWrite(11, 0); // Turn off UV LED
+                        UVLedOn = false;
                         ScanState = Sts_Idle;
                         SetReelsAsNeutral(HIGH, HIGH, HIGH);
                     }
@@ -754,7 +763,7 @@ void ReportPlotterInfo() {
             Previous_PT_Signal = PT_SignalLevelRead;
             PreviousFrameSteps = LastFrameSteps;
             if (IntegratedPlotter)  // Plotter info to ALT-Scann 8 Integrated plotter
-                SendToRPi(RSP_REPORT_PLOTTER_INFO, PT_SignalLevelRead, 0);
+                SendToRPi(RSP_REPORT_PLOTTER_INFO, PT_SignalLevelRead, PerforationThresholdLevel);
         }
     }
 }
@@ -861,7 +870,7 @@ boolean IsHoleDetected() {
     // To consider a frame is detected. After changing the condition to allow 20% less in the number of steps, I can see a better precision
     // In the captured frames. So for the moment it stays like this. Also added a fuse to also give a frame as detected in case of reaching
     // 150% of the required steps, even of the PT level does no tmatch the required threshold. We'll see...
-    if ((PT_Level >= PerforationThresholdLevel && FrameStepsDone >= int(MinFrameSteps*0.9)) || FrameStepsDone > int(MinFrameSteps * 1.5)) {
+    if ((PT_Level >= PerforationThresholdLevel && FrameStepsDone >= int((MinFrameSteps+FrameDeductSteps)*0.9)) || FrameStepsDone > int(MinFrameSteps * 1.5)) {
         hole_detected = true;
         GreenLedOn = true;
         analogWrite(A1, 255); // Light green led

--- a/tooltip.py
+++ b/tooltip.py
@@ -13,9 +13,9 @@ __author__ = 'Juan Remirez de Esparza'
 __copyright__ = "Copyright 2022¡4, Juan Remirez de Esparza"
 __credits__ = ["Juan Remirez de Esparza"]
 __license__ = "MIT"
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 __date__ = "2024-01-23"
-__version_highlight__ = "Tooltips common code for ALT-Scann8 and AfterScan"
+__version_highlight__ = "Bugfix - Tooltip covering small widgets"
 __maintainer__ = "Juan Remirez de Esparza"
 __email__ = "jremirez@hotmail.com"
 __status__ = "Development"
@@ -66,7 +66,7 @@ def show_tooltip(widget, text):
         x = screen_width - label.winfo_reqwidth()
     if widget.winfo_width() > 50:
         x -= 25
-    if widget.winfo_height() > 50:
+    if widget.winfo_height() > 100:
         y -= 25
     tooltip_window.wm_geometry(f"+{x}+{y}")
 


### PR DESCRIPTION
* ALT-Scann8 1.8.40 (#59)

- HDR merge-in-place now works. But, as anticipated, is too slow (around 11 FPM, vs 36 FPM without). Rough extrapolation for RPi5 (x2.5 RPi4) would be 27 FPM, faster but still slow

* ALT-Scann8 1.8.41 (#61)

- Review of alignment of widgets, make them more evenly distributed, also in small screen mode

* ALT-Scann8 1.8.42 (#62)

- Fix some remaining alignment issues
- Display popup warning when running out of disk space
- Add disk space check to simulated capture loop (to test new popup)

* ALT-Scann8 1.8.43 (#63)

- Errors when starting in experimental or expert mode alone (only working when using both together)

* ALT-Scann8 1.8.43 (#64)

Arduino 1.0.3
- Bugfix for slow forward auto-stop. UV Led was switched off, so film detection could not work

* Plotter threshold (#65)

* ALT-Scann8 1.8.43 Arduino 1.0.3
- Add line with threshold level to integrated plotter
- Bugfix: Disable 'Merge in place' checkbox when HDR disabled

* ALT-Scann8 1.8.43 Arduino 1.0.3
- Add line with threshold level to integrated plotter
- Bugfix: Disable 'Merge in place' checkbox when HDR disabled

* ALT-Scann8 1.8.45
- Bugfix: Due to a problem with data arriving from Arduino via I2C, sometimes the threshold level was wrong. Root cause is unknow, for now we prevent plotting the wrong value

* Updated tooltip.py to latest version

* ALT-Scann8 1.8.46 (#66)

Arduino 1.0.5
- Extra steps can now be set to negative values (-30 to +30). When negative, they are subtracted from the minimum number of steps where Arduino will start considering the photo-transistor, if positive is still the same, unconditional number os steps are done after frame is detected, before snapshot is taken. Normally negative values shoudl not be needed, but today I had a weird case where even after physically adjusting the film gate position, frames were being detected too high. Need to check the scanner to see if there is something wrong. But then, it was the second movie of the day, and the first went perfectly fine (it had the same characteristics as the one with the problem)

* Multi resolution capture (#67)

* ALT-Scann8 1.8.47
- Replace file type (jpg/png) radio buttons with drop down
- Replace 'HQ' button with drop down
- Additional resolutions added in drop-down (although minimum captor in HQ camera is "2028x1520" at the minimal, so no speed gain (need to search how to use format SRGGB10_CSI2P)
- Remove VideoCaptureMode as it served no purpose
- Move Multi-exposure frame to experimental area (as final results are not good) -

* ALT-Scann8 1.8.48
- Include raw mode 1332x990 (120.05 fps) in experimental mode (-x) only. This allows faster scanning (350FPM with no stabilization delay), but requires to physically open the zoom in the lens since it appear sto use only the center of the sensor. Not very useful, but included anyhow
- Log camera sensor modes omn startup, for info

* ALT-Scann8 1.8.48
- Fix 3 pyflakes minor issues

* ALT-Scann8 1.8.48
- Save window position upon exit to restore it in the next run

* ALT-Scann8 1.8.48
- Reduce font of rewind/FF buttons (when clicking of them were automatically getting bigger to accommodate 'Stop' text)
- Remove a lot of 'Win.update()' that were not really needed (they were causing scan process to become progressive slower)

* ALT-Scann8 1.9.0
- Set version to 1.9.0 before merging to develop, and then to master