### PR TITLE
ALT-Scann8 1.9.1

### DIFF
--- a/ALT-Scann8-Controller.ino
+++ b/ALT-Scann8-Controller.ino
@@ -18,9 +18,9 @@ More info in README.md file
 #define __copyright__   "Copyright 2023, Juan Remirez de Esparza"
 #define __credits__     "Juan Remirez de Esparza"
 #define __license__     "MIT"
-#define __version__     "1.0.5"
-#define  __date__       "2024-02-03"
-#define  __version_highlight__  "Allow negative FrameExtraSteps: Deducted from MinFrameSteps on the fly"
+#define __version__     "1.0.6"
+#define  __date__       "2024-02-06"
+#define  __version_highlight__  "More reactive PT automatic threshold"
 #define __maintainer__  "Juan Remirez de Esparza"
 #define __email__       "jremirez@hotmail.com"
 #define __status__      "Development"
@@ -727,10 +727,10 @@ int GetLevelPT() {
     MinPT = min(PT_SignalLevelRead, MinPT);
     MaxPT_Dynamic = max(PT_SignalLevelRead*10, MaxPT_Dynamic);
     MinPT_Dynamic = min(PT_SignalLevelRead*10, MinPT_Dynamic);
-    if (MaxPT_Dynamic > MinPT_Dynamic) MaxPT_Dynamic-=2;
+    if (MaxPT_Dynamic > (MinPT_Dynamic+10)) MaxPT_Dynamic-=5;
     //if (MinPT_Dynamic < MaxPT_Dynamic) MinPT_Dynamic+=int((MaxPT_Dynamic-MinPT_Dynamic)/10);  // need to catch up quickly for overexposed frames (proportional to MaxPT to adapt to any scanner)
-    if (MinPT_Dynamic < MaxPT_Dynamic) MinPT_Dynamic+=2;  // need to catch up quickly for overexposed frames (proportional to MaxPT to adapt to any scanner)
-    if (PT_Level_Auto) {
+    if (MinPT_Dynamic < (MaxPT_Dynamic-10)) MinPT_Dynamic+=15;  // need to catch up quickly for overexposed frames (proportional to MaxPT to adapt to any scanner)
+    if (PT_Level_Auto && FrameStepsDone >= int((MinFrameSteps+FrameDeductSteps)*0.9)) {
         ratio = (float)PerforationThresholdAutoLevelRatio/100;
         fixed_margin = int((MaxPT_Dynamic-MinPT_Dynamic) * 0.2);
         user_margin = int((MaxPT_Dynamic-MinPT_Dynamic) * 0.8 * ratio);
@@ -741,7 +741,7 @@ int GetLevelPT() {
     // If relevant diff between max/min dinamic it means we have film passing by
     if (millis() - FilmDetectedTime > MaxFilmStallTime)
         NoFilmDetected = true;
-    else if (MaxPT_Dynamic-MinPT_Dynamic > MaxPT_Dynamic/4)
+    else if (MaxPT_Dynamic-MinPT_Dynamic >= MaxPT/4) 
         FilmDetectedTime = millis();
 
     return(PT_SignalLevelRead);

--- a/ALT-Scann8-UserInterface.py
+++ b/ALT-Scann8-UserInterface.py
@@ -19,8 +19,8 @@ __author__ = 'Juan Remirez de Esparza'
 __copyright__ = "Copyright 2022-23, Juan Remirez de Esparza"
 __credits__ = ["Juan Remirez de Esparza"]
 __license__ = "MIT"
-__version__ = "1.9.0"
-__date__ = "2024-02-05"
+__version__ = "1.9.1"
+__date__ = "2024-02-06"
 __version_highlight__ = "Multi-resolution capture"
 __maintainer__ = "Juan Remirez de Esparza"
 __email__ = "jremirez@hotmail.com"
@@ -225,6 +225,7 @@ plotter_height=180
 PrevPTValue = 0
 PrevThresholdLevel = 0
 MaxPT = 100
+MinPT = 800
 MatchWaitMargin = 50    # Margin allowed to consider exposure/WB matches previous frame
                         # % of absolute value (1 for AWB color gain, and 8000 for exposure)
                         # That ,means we wait until the difference between a frame and the previous one is less
@@ -2263,7 +2264,7 @@ def set_resolution(event):
 
 def UpdatePlotterWindow(PTValue, ThresholdLevel):
     global plotter_canvas
-    global MaxPT, PrevPTValue, PrevThresholdLevel
+    global MaxPT, MinPT, PrevPTValue, PrevThresholdLevel
     global plotter_width, plotter_height
 
     if plotter_canvas == None:
@@ -2273,7 +2274,9 @@ def UpdatePlotterWindow(PTValue, ThresholdLevel):
         return
 
     MaxPT = max(MaxPT,PTValue)
+    MinPT = min(MinPT,PTValue)
     plotter_canvas.create_text(10, 5, text=str(MaxPT), anchor='nw', font=f"Helvetica {8}")
+    plotter_canvas.create_text(10, plotter_height - 15, text=str(MinPT), anchor='nw', font=f"Helvetica {8}")
     # Shift the graph to the left
     for item in plotter_canvas.find_all():
         plotter_canvas.move(item, -5, 0)
@@ -2294,6 +2297,8 @@ def UpdatePlotterWindow(PTValue, ThresholdLevel):
     PrevThresholdLevel = ThresholdLevel
     if MaxPT > 100:  # Do not allow below 100
         MaxPT-=1 # Dynamic max
+    if MinPT < 800:  # Do not allow above 800
+        MinPT+=1 # Dynamic min
 
 
 # send_arduino_command: No response expected


### PR DESCRIPTION
- In the integrated plotter,display as well the minimum value Arduino 1.0.6:
- Improvement for frame alignment in special cases (films overexposed in the sprocket hole area, so that film is mostly transparent, causing PT levels to remin quite high with small variations). More aggressive PT automatic threshold is allowed. It is calculated as the middle point level of dynamic max/mit PT values, converging towards each other. Converging step is changed from 2 to 10 (faster convergence, so faster adaptation of threshold to current PT values)
- In Auto PT level mode, calculate the PT threshold only when the minimum steps per frame is reached, there is no use in doing it before, and also it was creating ugly bumps in the plotter graph that were making interpretation difficult