### PR TITLE
Bugfix 2024 02 09

### DIFF
--- a/ALT-Scann8-Controller.ino
+++ b/ALT-Scann8-Controller.ino
@@ -18,9 +18,9 @@ More info in README.md file
 #define __copyright__   "Copyright 2023, Juan Remirez de Esparza"
 #define __credits__     "Juan Remirez de Esparza"
 #define __license__     "MIT"
-#define __version__     "1.0.9"
-#define  __date__       "2024-02-08"
-#define  __version_highlight__  "New algorithm to detect if film present"
+#define __version__     "1.0.10"
+#define  __date__       "2024-02-09"
+#define  __version_highlight__  "Bugfixes film presence detection"
 #define __maintainer__  "Juan Remirez de Esparza"
 #define __email__       "jremirez@hotmail.com"
 #define __status__      "Development"
@@ -734,7 +734,7 @@ void CollectOutgoingFilm(void) {
 // ------------- Detect when PT curve becomes flat ---------------
 boolean film_detected(int pt_value)
 {
-    const int max_values = 20;
+    const int max_values = 50;
     static int rolling_pt_values[max_values];
     static int value_idx = 0, counter = 0;
     int total, max_value, min_value, global_variance, instant_variance;
@@ -752,7 +752,8 @@ boolean film_detected(int pt_value)
         }
         global_variance = MaxPT - MinPT;
         instant_variance = max_value - min_value;
-        if (abs(global_variance-instant_variance) < instant_variance * 4) 
+        // if (abs(global_variance-instant_variance) < 200)
+        if (instant_variance < 100)
             return(true);
         else
             return(false);

--- a/ALT-Scann8-Controller.ino
+++ b/ALT-Scann8-Controller.ino
@@ -395,7 +395,7 @@ void loop() {
                         scan_process_ongoing = true;
                         delay(200);     // Wait for PT to stabilize after switching UV led on
                         StartFrameTime = micros();
-                        FilmDetectedTime = millis();
+                        FilmDetectedTime = millis() + MaxFilmStallTime;
                         NoFilmDetected = false;
                         ScanSpeed = OriginalScanSpeed;
                         collect_timer = scan_collect_timer;
@@ -445,7 +445,7 @@ void loop() {
                         break;
                     case CMD_FILM_FORWARD:
                         SetReelsAsNeutral(HIGH, LOW, LOW);
-                        FilmDetectedTime = millis();
+                        FilmDetectedTime = millis() + MaxFilmStallTime;
                         NoFilmDetected = false;
                         collect_timer = 10;
                         analogWrite(11, UVLedBrightness); // Turn on UV LED
@@ -734,36 +734,32 @@ void CollectOutgoingFilm(void) {
 // ------------- Detect when PT curve becomes flat ---------------
 boolean film_detected(int pt_value)
 {
-    const int max_values = 50;
-    static int rolling_pt_values[max_values];
-    static int value_idx = 0, counter = 0;
-    int total, max_value, min_value, global_variance, instant_variance;
+    static int max_value, min_value;
+    int instant_variance;
+    static unsigned long time_to_renew_minmax = 0;
+    unsigned long CurrentTime = millis();
+    int minmax_validity_time = 2000;  // Renew min max values every two seconds
 
-    rolling_pt_values[value_idx] = pt_value;
-    value_idx = (value_idx+1) % max_values;
-    if (counter < max_values) counter ++;
-    if (counter >= max_values) {
-        total = 0;
-        max_value = MinPT;
-        min_value = MaxPT;
-        for (int i= 0; i < max_values; i++) {
-            max_value = max(max_value, rolling_pt_values[i]);
-            min_value = min(min_value, rolling_pt_values[i]);
-        }
-        global_variance = MaxPT - MinPT;
-        instant_variance = max_value - min_value;
-        // if (abs(global_variance-instant_variance) < 200)
-        if (instant_variance < 100)
-            return(true);
-        else
-            return(false);
+    if (CurrentTime > time_to_renew_minmax || time_to_renew_minmax - CurrentTime > minmax_validity_time) {
+      time_to_renew_minmax = CurrentTime + minmax_validity_time;
+      max_value = MinPT;
+      min_value = MaxPT;
     }
-    return(true);
+    max_value = max(max_value, pt_value);
+    min_value = min(min_value, pt_value);
+
+    instant_variance = max_value - min_value;
+    if (instant_variance > 30)
+        return(true);
+    else
+        return(false);
 }
+
 // ------------- Centralized phototransistor level read ---------------
 int GetLevelPT() {
     float ratio;
     int user_margin, fixed_margin, average_pt;
+    unsigned long CurrentTime = millis();
 
     PT_SignalLevelRead = analogRead(PHOTODETECT);
     MaxPT = max(PT_SignalLevelRead, MaxPT);
@@ -782,11 +778,14 @@ int GetLevelPT() {
     }
 
     // If relevant diff between max/min dinamic it means we have film passing by
-    if (millis() - FilmDetectedTime > MaxFilmStallTime){
+    if (CurrentTime > FilmDetectedTime) {
         NoFilmDetected = true;
     }
+    else if (FilmDetectedTime - CurrentTime > MaxFilmStallTime) { // Overrun: Normalize value
+        FilmDetectedTime = millis() + MaxFilmStallTime;
+    }
     else if (film_detected(PT_SignalLevelRead)) {
-        FilmDetectedTime = millis();
+        FilmDetectedTime = millis() + MaxFilmStallTime;
     }
 
     return(PT_SignalLevelRead);

--- a/ALT-Scann8-UserInterface.py
+++ b/ALT-Scann8-UserInterface.py
@@ -19,9 +19,9 @@ __author__ = 'Juan Remirez de Esparza'
 __copyright__ = "Copyright 2022-23, Juan Remirez de Esparza"
 __credits__ = ["Juan Remirez de Esparza"]
 __license__ = "MIT"
-__version__ = "1.9.3"
-__date__ = "2024-02-08"
-__version_highlight__ = "Multi-resolution capture"
+__version__ = "1.9.4"
+__date__ = "2024-02-09"
+__version_highlight__ = "Bugfixes film presence detection"
 __maintainer__ = "Juan Remirez de Esparza"
 __email__ = "jremirez@hotmail.com"
 __status__ = "Development"
@@ -331,6 +331,8 @@ def exit_app():  # Exit Application
             camera.close()
     # Set window position for next run
     SessionData["WindowPos"] = win.geometry()
+    SessionData["AutoStopActive"] = auto_stop_enabled.get()
+    SessionData["AutoStopType"] = autostop_type.get()
     # Write session data upon exit
     with open(PersistedDataFilename, 'w') as f:
         json.dump(SessionData, f)
@@ -361,6 +363,8 @@ def set_free_mode():
 def set_auto_stop_enabled():
     if not SimulatedRun:
         send_arduino_command(CMD_SET_AUTO_STOP, auto_stop_enabled.get())
+    autostop_no_film_rb.config(state=NORMAL if auto_stop_enabled.get() else DISABLED)
+    autostop_counter_zero_rb.config(state=NORMAL if auto_stop_enabled.get() else DISABLED)
     logging.debug(f"Set Auto Stop: {auto_stop_enabled.get()}")
 
 
@@ -529,11 +533,14 @@ def set_existing_folder():
         current_frame_str = '0'
     NewCurrentFrame = int(current_frame_str)
 
-    if NewCurrentFrame <= filecount:
+    if filecount > 0 and NewCurrentFrame <= filecount:
         confirm = tk.messagebox.askyesno(title='Files exist in target folder',
                                          message=f"Newly selected folder already contains {filecount} files."
                                          f"\r\nSetting {NewCurrentFrame} as initial frame will overwrite some of them."
                                          f"Are you sure you want to continue?")
+    else:
+        confirm = True
+
     if confirm:
         CurrentFrame = NewCurrentFrame
         CurrentDir = NewDir
@@ -2169,6 +2176,8 @@ def capture_loop():
                     if FramesPerMinute != 0:
                         minutes_pending = FramesToGo // FramesPerMinute
                         time_to_go_str.set(f"Time to go: {(minutes_pending // 60):02} h, {(minutes_pending % 60):02} m")
+                else:
+                    ScanStopRequested = True  # Stop in next capture loop
             CurrentFrame += 1
             session_frames += 1
             register_frame()
@@ -2567,8 +2576,10 @@ def load_session_data():
                 negative_image.set(eval(SessionData["NegativeCaptureActive"]))
                 set_negative_image()
             if 'AutoStopActive' in SessionData:
-                auto_stop_enabled.set(eval(SessionData["AutoStopActive"]))
+                auto_stop_enabled.set(SessionData["AutoStopActive"])
                 set_auto_stop_enabled()
+            if 'AutoStopType' in SessionData:
+                autostop_type.set(SessionData["AutoStopType"])
             if ExperimentalMode:
                 if 'HdrCaptureActive' in SessionData:
                     HdrCaptureActive = eval(SessionData["HdrCaptureActive"])
@@ -3001,6 +3012,8 @@ def build_ui():
     global Scanned_Images_number_str, Scanned_Images_time_str, Scanned_Images_Fpm_str
     global resolution_label, resolution_dropdown, file_type_label, file_type_dropdown
     global existing_folder_btn, new_folder_btn
+    global autostop_no_film_rb, autostop_counter_zero_rb, autostop_type
+
 
 
     # Create a frame to contain the top area (preview + Right buttons) ***************
@@ -3121,13 +3134,33 @@ def build_ui():
     setup_tooltip(focus_rt_btn, "Move zoom view to the right.")
     bottom_area_row += 1
 
+    # Frame for automatic stop & methods
+    autostop_frame = Frame(top_left_area_frame)
+    autostop_frame.grid(row=bottom_area_row, column=bottom_area_column, columnspan=2, padx=2, pady=1, sticky='WE')
+
     # Activate focus zoom, to facilitate focusing the camera
     auto_stop_enabled = tk.BooleanVar(value=False)
-    auto_stop_enabled_checkbox = tk.Checkbutton(top_left_area_frame, text='Automatic stop', height=1,
+    auto_stop_enabled_checkbox = tk.Checkbutton(autostop_frame, text='Auto-stop if', height=1,
                                                  variable=auto_stop_enabled, onvalue=True, offvalue=False,
                                                  font=("Arial", FontSize), command=set_auto_stop_enabled)
-    auto_stop_enabled_checkbox.grid(row=bottom_area_row, column=bottom_area_column, columnspan=2, padx=2, pady=1, sticky='W')
+    #auto_stop_enabled_checkbox.grid(row=bottom_area_row, column=bottom_area_column, columnspan=2, padx=2, pady=1, sticky='W')
+    auto_stop_enabled_checkbox.pack(side = TOP, anchor=W)
     setup_tooltip(auto_stop_enabled_checkbox, "Stop scanning when end of film detected")
+
+    # Radio buttons to select auto-stop method
+    autostop_type = tk.StringVar()
+    autostop_type.set('No_film')
+    autostop_no_film_rb = tk.Radiobutton(autostop_frame, text="No film", variable=autostop_type,
+                                  value='No_film', font=("Arial", FontSize))
+    autostop_no_film_rb.pack(side=TOP, anchor=W, padx=10)
+    setup_tooltip(autostop_no_film_rb, "Stop when film is not detected by PT")
+    autostop_counter_zero_rb = tk.Radiobutton(autostop_frame, text="Count zero", variable=autostop_type,
+                                  value='counter_to_zero', font=("Arial", FontSize))
+    autostop_counter_zero_rb.pack(side=TOP, anchor=W, padx=10)
+    setup_tooltip(autostop_counter_zero_rb, "Stop scan when frames-to-go counter reaches zero")
+    autostop_no_film_rb.config(state = DISABLED)
+    autostop_counter_zero_rb.config(state = DISABLED)
+
     bottom_area_row += 1
 
     # Create vertical button column at right *************************************


### PR DESCRIPTION
- Final fixes for automatic scanner stop when end of film detected
- Alternate method for automatic stop: Instead of detecting end of film, it will stop when the 'frames-to-go' counter reaches zero