### PR TITLE
Review handling of values from widgets

### DIFF
--- a/ALT-Scann8-UserInterface.py
+++ b/ALT-Scann8-UserInterface.py
@@ -575,6 +575,7 @@ def exposure_selection():
         return
 
     if AE_enabled.get():  # Do not allow spinbox changes when in auto mode (should not happen as spinbox is readonly)
+        exposure_value.set(CurrentExposure / 1000)
         return
 
     CurrentExposure = exposure_value.get() * 1000
@@ -637,6 +638,7 @@ def wb_red_selection():
         return
 
     if AWB_enabled.get():  # Do not allow spinbox changes when in auto mode (should not happen as spinbox is readonly)
+        wb_red_str.set(str(GainRed))
         return
 
     GainRed = float(wb_red_str.get())
@@ -656,6 +658,7 @@ def wb_blue_selection():
         return
 
     if AWB_enabled.get():  # Do not allow spinbox changes when in auto mode (should not happen as spinbox is readonly)
+        wb_blue_str.set(str(GainBlue))
         return
 
     GainBlue = float(wb_blue_str.get())
@@ -2680,7 +2683,10 @@ def load_session_data():
                     if ExposureAdaptPause:
                         auto_exp_wait_checkbox.select()
                 if 'CurrentAwbAuto' in SessionData:
-                    AWB_enabled.set(eval(SessionData["CurrentAwbAuto"]))
+                    if isinstance(AWB_enabled, bool):
+                        AWB_enabled.set(eval(SessionData["CurrentAwbAuto"]))
+                    else:
+                        AWB_enabled.set(SessionData["CurrentAwbAuto"])
                     wb_blue_spinbox.config(state='readonly' if AWB_enabled.get() else NORMAL)
                     wb_red_spinbox.config(state='readonly' if AWB_enabled.get() else NORMAL)
                     awb_red_wait_checkbox.config(state=NORMAL if AWB_enabled.get() else DISABLED)

--- a/ALT-Scann8-UserInterface.py
+++ b/ALT-Scann8-UserInterface.py
@@ -789,33 +789,33 @@ def stabilization_delay_spinbox_focus_out(event):
     SessionData["CaptureStabilizationDelay"] = str(CaptureStabilizationDelay)
 
 
-def sharpness_control_selection(updown):
+def sharpness_control_selection():
     global sharpness_control_label
     global SharpnessValue
-    global sharpness_control_spinbox, sharpness_control_str
+    global sharpness_control_spinbox
     global SimulatedRun
 
     if not ExpertMode:
         return
 
-    SharpnessValue = int(sharpness_control_spinbox.get())
-    SessionData["SharpnessValue"] = str(SharpnessValue)
+    SharpnessValue = sharpness_control_value.get()
+    SessionData["SharpnessValue"] = SharpnessValue
 
 
 def sharpness_control_spinbox_focus_out(event):
     global sharpness_control_label
     global SharpnessValue
-    global sharpness_control_spinbox, sharpness_control_str
+    global sharpness_control_spinbox
     global SimulatedRun
 
-    SharpnessValue = int(sharpness_control_spinbox.get())
-    SessionData["SharpnessValue"] = str(SharpnessValue)
+    SharpnessValue = sharpness_control_value.get()
+    SessionData["SharpnessValue"] = SharpnessValue
 
 
 def rwnd_speed_control_selection(updown):
     global rwnd_speed_control_label
     global rwnd_speed_delay
-    global rwnd_speed_control_spinbox, rwnd_speed_control_str
+    global rwnd_speed_control_spinbox
     global SimulatedRun
 
     if not ExpertMode:
@@ -972,17 +972,17 @@ def scan_speed_spinbox_focus_out(event):
     send_arduino_command(CMD_SET_SCAN_SPEED, ScanSpeed)
 
 
-def hdr_check_min_exp(event):
-    global hdr_min_exp_spinbox, hdr_min_exp_str, hdr_min_exp, recalculate_hdr_exp_list
-    global hdr_max_exp, hdr_max_exp_str
-    global hdr_bracket_width, hdr_bracket_width_str
+def hdr_check_min_exp():
+    global hdr_min_exp_spinbox, hdr_min_exp, recalculate_hdr_exp_list
+    global hdr_max_exp
+    global hdr_bracket_width
     global force_adjust_hdr_bracket
 
     if not ExpertMode:
         return
 
     save_value = hdr_min_exp
-    hdr_min_exp = int(hdr_min_exp_str.get())
+    hdr_min_exp = hdr_min_exp_value.get()
     if hdr_min_exp < hdr_lower_exp:
         hdr_min_exp = hdr_lower_exp
     hdr_max_exp = hdr_min_exp + hdr_bracket_width
@@ -990,9 +990,9 @@ def hdr_check_min_exp(event):
         hdr_bracket_width -= hdr_max_exp-1000  # Reduce bracket
         hdr_max_exp = 1000
         force_adjust_hdr_bracket = True
-    hdr_min_exp_str.set(str(hdr_min_exp))
-    hdr_max_exp_str.set(hdr_max_exp)
-    hdr_bracket_width_str.set(hdr_bracket_width)
+    hdr_min_exp_value.set(hdr_min_exp)
+    hdr_max_exp_value.set(hdr_max_exp)
+    hdr_bracket_width_value.set(hdr_bracket_width)
     if save_value != hdr_min_exp:
         recalculate_hdr_exp_list = True
     SessionData["HdrMinExp"] = hdr_min_exp
@@ -1000,17 +1000,17 @@ def hdr_check_min_exp(event):
     SessionData["HdrBracketWidth"] = hdr_max_exp
 
 
-def hdr_check_max_exp(event):
-    global hdr_max_exp_spinbox, hdr_min_exp_str, hdr_min_exp, recalculate_hdr_exp_list
-    global hdr_max_exp, hdr_max_exp_str
-    global hdr_bracket_width, hdr_bracket_width_str
+def hdr_check_max_exp():
+    global hdr_min_exp, recalculate_hdr_exp_list
+    global hdr_max_exp
+    global hdr_bracket_width
     global force_adjust_hdr_bracket
 
     if not ExpertMode:
         return
 
     save_value = hdr_max_exp
-    hdr_max_exp = int(hdr_max_exp_str.get())
+    hdr_max_exp = hdr_max_exp_value.get()
     if hdr_max_exp > 1000:
         hdr_max_exp = 1000
     if (hdr_max_exp > hdr_min_exp):
@@ -1022,9 +1022,9 @@ def hdr_check_max_exp(event):
         hdr_min_exp = hdr_lower_exp
         hdr_bracket_width = hdr_max_exp - hdr_min_exp  # Reduce bracket
         force_adjust_hdr_bracket = True
-    hdr_min_exp_str.set(str(hdr_min_exp))
-    hdr_max_exp_str.set(hdr_max_exp)
-    hdr_bracket_width_str.set(hdr_bracket_width)
+    hdr_min_exp_value.set(hdr_min_exp)
+    hdr_max_exp_value.set(hdr_max_exp)
+    hdr_bracket_width_value.set(hdr_bracket_width)
     if save_value != hdr_max_exp:
         recalculate_hdr_exp_list = True
     SessionData["HdrMinExp"] = hdr_min_exp
@@ -1033,9 +1033,9 @@ def hdr_check_max_exp(event):
 
 
 def hdr_check_bracket_width():
-    global hdr_bracket_width_spinbox, hdr_bracket_width_str, hdr_bracket_width
-    global hdr_min_exp, hdr_min_exp_str
-    global hdr_max_exp, hdr_max_exp_str
+    global hdr_bracket_width_spinbox, hdr_bracket_width
+    global hdr_min_exp
+    global hdr_max_exp
     global recalculate_hdr_exp_list
     global force_adjust_hdr_bracket
 
@@ -1043,14 +1043,14 @@ def hdr_check_bracket_width():
         return
 
     save_value = hdr_bracket_width
-    hdr_bracket_width = int(hdr_bracket_width_str.get())
+    hdr_bracket_width = hdr_bracket_width_value.get()
 
     if (hdr_bracket_width < hdr_min_bracket_width):
         hdr_bracket_width = hdr_min_bracket_width
-        hdr_bracket_width_str.set(hdr_bracket_width)
+        hdr_bracket_width_value.set(hdr_bracket_width)
     if (hdr_bracket_width > hdr_max_bracket_width):
         hdr_bracket_width = hdr_max_bracket_width
-        hdr_bracket_width_str.set(hdr_bracket_width)
+        hdr_bracket_width_value.set(hdr_bracket_width)
 
     if save_value != hdr_bracket_width:
         force_adjust_hdr_bracket = True
@@ -1061,16 +1061,16 @@ def hdr_check_bracket_width():
             hdr_max_exp = hdr_min_exp + hdr_bracket_width
         else:
             hdr_max_exp = int(middle_exp + (hdr_bracket_width/2))
-        hdr_min_exp_str.set(str(hdr_min_exp))
-        hdr_max_exp_str.set(hdr_max_exp)
+        hdr_min_exp_value.set(hdr_min_exp)
+        hdr_max_exp_value.set(hdr_max_exp)
         SessionData["HdrMinExp"] = hdr_min_exp
         SessionData["HdrMaxExp"] = hdr_max_exp
         SessionData["HdrBracketWidth"] = hdr_bracket_width
 
 
 def hdr_check_bracket_shift():
-    global hdr_bracket_shift_str, hdr_bracket_shift
-    hdr_bracket_shift = int(hdr_bracket_shift_str.get())
+    global hdr_bracket_shift
+    hdr_bracket_shift = hdr_bracket_shift_value.get()
 
 
 
@@ -1461,10 +1461,6 @@ def disk_space_available():
 
 
 def hdr_set_controls():
-    global hdr_capture_active
-    global hdr_bracket_width_label, hdr_bracket_shift_label, hdr_bracket_width_spinbox, hdr_bracket_shift_spinbox
-    global hdr_viewx4_active_checkbox, hdr_min_exp_label, hdr_min_exp_spinbox, hdr_max_exp_label, hdr_max_exp_spinbox
-    global hdr_merge_in_place_checkbox
 
     if not ExpertMode:
         return
@@ -1769,7 +1765,6 @@ def adjust_hdr_bracket():
     global camera, HdrCaptureActive
     global recalculate_hdr_exp_list, dry_run_iterations
     global hdr_min_exp, hdr_max_exp, hdr_best_exp, hdr_bracket_width
-    global hdr_min_exp_str, hdr_max_exp_str
     global PreviousCurrentExposure, HdrBracketAuto
     global hdr_max_exp_spinbox, hdr_min_exp_spinbox
     global save_bg, save_fg
@@ -1795,9 +1790,9 @@ def adjust_hdr_bracket():
         PreviousCurrentExposure = aux_current_exposure
         hdr_best_exp = aux_current_exposure
         hdr_min_exp = max(hdr_best_exp-int(hdr_bracket_width/2), hdr_lower_exp)
-        hdr_min_exp_str.set(str(hdr_min_exp))
+        hdr_min_exp_value.set(hdr_min_exp)
         hdr_max_exp = hdr_min_exp + hdr_bracket_width
-        hdr_max_exp_str.set(hdr_max_exp)
+        hdr_max_exp_value.set(hdr_max_exp)
         SessionData["HdrMinExp"] = hdr_min_exp
         SessionData["HdrMaxExp"] = hdr_max_exp
         recalculate_hdr_exp_list = True
@@ -2316,7 +2311,10 @@ def onesec_periodic_checks():  # Update RPi temperature every 10 seconds
           f"match_wait_margin_value: {match_wait_margin_value.get()}, min_frame_steps_value: {min_frame_steps_value.get()}, "
           f"pt_level_value: {pt_level_value.get()}, frame_fine_tune_value: {frame_fine_tune_value.get()}, "
           f"frame_extra_steps_value: {frame_extra_steps_value.get()}, scan_speed_value: {scan_speed_value.get()}, "
-          f"stabilization_delay_value: {stabilization_delay_value.get()}")
+          f"stabilization_delay_value: {stabilization_delay_value.get()}, hdr_min_exp_value: {hdr_min_exp_value.get()}, "
+          f"hdr_max_exp_value: {hdr_max_exp_value.get()}, hdr_bracket_width_value: {hdr_bracket_width_value.get()}, "
+          f"hdr_bracket_shift_value: {hdr_bracket_shift_value.get()}, sharpness_control_value: {sharpness_control_value.get()}, "
+          f"rwnd_speed_control_value: {rwnd_speed_control_value.get()}")
 
     win.after(1000, onesec_periodic_checks)
 
@@ -2574,7 +2572,7 @@ def load_session_data():
     global hdr_capture_active_checkbox, HdrCaptureActive
     global hdr_viewx4_active_checkbox, HdrViewX4Active
     global hdr_min_exp, hdr_max_exp, hdr_bracket_width_auto_checkbox
-    global hdr_min_exp_str, hdr_max_exp_str, hdr_bracket_width
+    global hdr_bracket_width
     global HdrBracketAuto, hdr_bracket_auto, hdr_min_exp, hdr_max_exp, hdr_max_exp_spinbox, hdr_min_exp_spinbox
     global HdrMergeInPlace, hdr_merge_in_place
     global exposure_btn, wb_red_btn, wb_blue_btn, exposure_spinbox, wb_red_spinbox, wb_blue_spinbox
@@ -2642,13 +2640,13 @@ def load_session_data():
                     if HdrViewX4Active and ExpertMode:
                         hdr_viewx4_active_checkbox.select()
                 if 'HdrMinExp' in SessionData:
-                    hdr_min_exp = SessionData["HdrMinExp"]
+                    hdr_min_exp = int(SessionData["HdrMinExp"])
                     if ExpertMode:
-                        hdr_min_exp_str.set(hdr_min_exp)
+                        hdr_min_exp_value.set(hdr_min_exp)
                 if 'HdrMaxExp' in SessionData:
-                    hdr_max_exp = SessionData["HdrMaxExp"]
+                    hdr_max_exp = int(SessionData["HdrMaxExp"])
                     if ExpertMode:
-                        hdr_max_exp_str.set(hdr_max_exp)
+                        hdr_max_exp_value.set(hdr_max_exp)
                 if 'HdrBracketAuto' in SessionData:
                     HdrBracketAuto = SessionData["HdrBracketAuto"]
                     hdr_bracket_auto.set(HdrBracketAuto)
@@ -2660,11 +2658,11 @@ def load_session_data():
                 if 'HdrMaxExp' in SessionData:
                     hdr_max_exp = SessionData["HdrMaxExp"]
                 if 'HdrBracketWidth' in SessionData:
-                    hdr_bracket_width = SessionData["HdrBracketWidth"]
-                    hdr_bracket_width_str.set(str(hdr_bracket_width))
+                    hdr_bracket_width = int(SessionData["HdrBracketWidth"])
+                    hdr_bracket_width_value.set(hdr_bracket_width)
                 if 'HdrBracketShift' in SessionData:
                     hdr_bracket_shift = SessionData["HdrBracketShift"]
-                    hdr_bracket_shift_str.set(str(hdr_bracket_shift))
+                    hdr_bracket_shift_value.set(hdr_bracket_shift)
             if ExpertMode:
                 if 'CurrentExposure' in SessionData:
                     aux = SessionData["CurrentExposure"]
@@ -3086,17 +3084,16 @@ def create_widgets():
     global wb_red_spinbox, wb_blue_spinbox, wb_red_str, wb_blue_str
     global match_wait_margin_spinbox, match_wait_margin_value
     global stabilization_delay_spinbox, stabilization_delay_value
-    global sharpness_control_spinbox, sharpness_control_str
-    global rwnd_speed_control_spinbox, rwnd_speed_control_str
+    global sharpness_control_spinbox, sharpness_control_value
+    global rwnd_speed_control_spinbox, rwnd_speed_control_value
     global Manual_scan_activated, ManualScanEnabled, manual_scan_advance_fraction_5_btn, manual_scan_advance_fraction_20_btn, manual_scan_take_snap_btn
     global plotter_canvas
     global hdr_capture_active_checkbox, hdr_capture_active, hdr_viewx4_active
-    global hdr_min_exp_str, hdr_max_exp_str
-    global hdr_viewx4_active_checkbox, hdr_min_exp_label, hdr_min_exp_spinbox, hdr_max_exp_label, hdr_max_exp_spinbox
+    global hdr_viewx4_active_checkbox, hdr_min_exp_label, hdr_min_exp_spinbox, hdr_max_exp_label, hdr_max_exp_spinbox, hdr_max_exp_value, hdr_min_exp_value
     global min_frame_steps_btn, auto_framesteps_enabled, pt_level_btn, auto_pt_level_enabled
     global exposure_btn, wb_red_btn, wb_blue_btn, exposure_spinbox, wb_red_spinbox, wb_blue_spinbox
     global hdr_bracket_width_spinbox, hdr_bracket_shift_spinbox, hdr_bracket_width_label, hdr_bracket_shift_label
-    global hdr_bracket_width_str, hdr_bracket_shift_str, hdr_bracket_width, hdr_bracket_shift
+    global hdr_bracket_width_value, hdr_bracket_shift_value, hdr_bracket_width, hdr_bracket_shift
     global hdr_bracket_auto, hdr_bracket_width_auto_checkbox
     global hdr_merge_in_place, hdr_bracket_width_auto_checkbox, hdr_merge_in_place_checkbox
     global frames_to_go_str, FramesToGo, time_to_go_str
@@ -3670,42 +3667,38 @@ def create_widgets():
 
         hdr_min_exp_label = tk.Label(hdr_frame, text='Lower exp. (ms):', font=("Arial", FontSize-1), state=DISABLED)
         hdr_min_exp_label.grid(row=hdr_row, column=0, padx=2, pady=1, sticky=E)
-        hdr_min_exp_str = tk.StringVar(value=str(hdr_min_exp))
-        hdr_min_exp_spinbox = tk.Spinbox(hdr_frame, command=(hdr_check_min_exp, '%d'), width=8,
-            textvariable=hdr_min_exp_str, from_=hdr_lower_exp, to=999, increment=1, font=("Arial", FontSize-1), state=DISABLED)
+        hdr_min_exp_value = tk.IntVar(value=hdr_min_exp)
+        hdr_min_exp_spinbox = tk.Spinbox(hdr_frame, command=hdr_check_min_exp, width=8,
+            textvariable=hdr_min_exp_value, from_=hdr_lower_exp, to=999, increment=1, font=("Arial", FontSize-1), state=DISABLED)
         hdr_min_exp_spinbox.grid(row=hdr_row, column=1, padx=2, pady=1, sticky=W)
         setup_tooltip(hdr_min_exp_spinbox, "When multi-exposure enabled, lower value of the exposure bracket.")
-        hdr_min_exp_spinbox.bind("<FocusOut>", hdr_check_min_exp)
         hdr_row +=1
 
         hdr_max_exp_label = tk.Label(hdr_frame, text='Higher exp. (ms):', font=("Arial", FontSize-1), state=DISABLED)
         hdr_max_exp_label.grid(row=hdr_row, column=0, padx=2, pady=1, sticky=E)
-        hdr_max_exp_str = tk.StringVar(value=str(hdr_max_exp))
-        hdr_max_exp_spinbox = tk.Spinbox(hdr_frame, command=(hdr_check_max_exp, '%d'), width=8,
-            textvariable=hdr_max_exp_str, from_=2, to=1000, increment=1, font=("Arial", FontSize-1), state=DISABLED)
+        hdr_max_exp_value = tk.IntVar(value=hdr_max_exp)
+        hdr_max_exp_spinbox = tk.Spinbox(hdr_frame, command=hdr_check_max_exp, width=8,
+            textvariable=hdr_max_exp_value, from_=2, to=1000, increment=1, font=("Arial", FontSize-1), state=DISABLED)
         hdr_max_exp_spinbox.grid(row=hdr_row, column=1, padx=2, pady=1, sticky=W)
         setup_tooltip(hdr_max_exp_spinbox, "When multi-exposure enabled, upper value of the exposure bracket.")
-        hdr_max_exp_spinbox.bind("<FocusOut>", hdr_check_max_exp)
         hdr_row += 1
 
         hdr_bracket_width_label = tk.Label(hdr_frame, text='Bracket width (ms):', font=("Arial", FontSize-1), state=DISABLED)
         hdr_bracket_width_label.grid(row=hdr_row, column=0, padx=2, pady=1, sticky=E)
-        hdr_bracket_width_str = tk.StringVar(value=str(hdr_bracket_width))
+        hdr_bracket_width_value = tk.IntVar(value=hdr_bracket_width)
         hdr_bracket_width_spinbox = tk.Spinbox(hdr_frame, command=hdr_check_bracket_width, width=8,
-            textvariable=hdr_bracket_width_str, from_=hdr_min_bracket_width, to=hdr_max_bracket_width, increment=1, font=("Arial", FontSize-1), state=DISABLED)
+            textvariable=hdr_bracket_width_value, from_=hdr_min_bracket_width, to=hdr_max_bracket_width, increment=1, font=("Arial", FontSize-1), state=DISABLED)
         hdr_bracket_width_spinbox.grid(row=hdr_row, column=1, padx=2, pady=1, sticky=W)
         setup_tooltip(hdr_bracket_width_spinbox, "When multi-exposure enabled, width of the exposure bracket (useful for automatic mode).")
-        hdr_bracket_width_spinbox.bind("<FocusOut>", lambda event: hdr_check_bracket_width())
         hdr_row += 1
 
         hdr_bracket_shift_label = tk.Label(hdr_frame, text='Bracket shift (ms):', font=("Arial", FontSize-1), state=DISABLED)
         hdr_bracket_shift_label.grid(row=hdr_row, column=0, padx=2, pady=1, sticky=E)
-        hdr_bracket_shift_str = tk.StringVar(value=str(hdr_bracket_shift))
+        hdr_bracket_shift_value = tk.IntVar(value=hdr_bracket_shift)
         hdr_bracket_shift_spinbox = tk.Spinbox(hdr_frame, command=hdr_check_bracket_shift, width=8,
-            textvariable=hdr_bracket_shift_str, from_=-100, to=100, increment=10, font=("Arial", FontSize-1), state=DISABLED)
+            textvariable=hdr_bracket_shift_value, from_=-100, to=100, increment=10, font=("Arial", FontSize-1), state=DISABLED)
         hdr_bracket_shift_spinbox.grid(row=hdr_row, column=1, padx=2, pady=1, sticky=W)
         setup_tooltip(hdr_bracket_shift_spinbox, "When multi-exposure enabled, shift exposure bracket up or down from default position.")
-        hdr_bracket_shift_spinbox.bind("<FocusOut>", lambda event: hdr_check_bracket_shift())
         hdr_row += 1
 
         hdr_bracket_auto = tk.BooleanVar(value=HdrBracketAuto)
@@ -3732,30 +3725,22 @@ def create_widgets():
                                              text='Sharpness:',
                                              font=("Arial", FontSize-1))
         sharpness_control_label.grid(row=0, column=0, padx=2, sticky=E)
-        sharpness_control_str = tk.StringVar(value=str(SharpnessValue))
-        sharpness_control_selection_aux = experimental_miscellaneous_frame.register(
-            sharpness_control_selection)
-        sharpness_control_spinbox = tk.Spinbox(
-            experimental_miscellaneous_frame,
-            command=(sharpness_control_selection_aux, '%d'), width=8,
-            textvariable=sharpness_control_str, from_=0, to=16, increment=1, font=("Arial", FontSize-1))
+        sharpness_control_value = tk.IntVar(value=SharpnessValue)
+        sharpness_control_spinbox = tk.Spinbox(experimental_miscellaneous_frame, command=sharpness_control_selection,
+                                               width=8, textvariable=sharpness_control_value, from_=0, to=16,
+                                               increment=1, font=("Arial", FontSize-1))
         sharpness_control_spinbox.grid(row=0, column=1, padx=2, sticky=W)
         setup_tooltip(sharpness_control_spinbox,
                       "Sets the RPi HQ camera 'Sharpness' property to the selected value.")
-        sharpness_control_spinbox.bind("<FocusOut>", sharpness_control_spinbox_focus_out)
         # Display entry to throttle Rwnd/FF speed
         rwnd_speed_control_label = tk.Label(experimental_miscellaneous_frame,
                                              text='RW/FF speed rpm):',
                                              font=("Arial", FontSize-1))
         rwnd_speed_control_label.grid(row=1, column=0, padx=2, sticky=E)
-        rwnd_speed_control_str = tk.StringVar(value=str(round(60 / (rwnd_speed_delay * 375 / 1000000))))
-
-        rwnd_speed_control_selection_aux = experimental_miscellaneous_frame.register(
-            rwnd_speed_control_selection)
-        rwnd_speed_control_spinbox = tk.Spinbox(
-            experimental_miscellaneous_frame, state='readonly',
-            command=(rwnd_speed_control_selection_aux, '%d'), width=8,
-            textvariable=rwnd_speed_control_str, from_=40, to=800, increment=50, font=("Arial", FontSize-1))
+        rwnd_speed_control_value = tk.IntVar(value=round(60 / (rwnd_speed_delay * 375 / 1000000)))
+        rwnd_speed_control_spinbox = tk.Spinbox(experimental_miscellaneous_frame, state='readonly', width=8,
+                                                command=(rwnd_speed_control_selection, '%d'), from_=40, to=800, increment=50,
+                                                textvariable=rwnd_speed_control_value, font=("Arial", FontSize-1))
         rwnd_speed_control_spinbox.grid(row=1, column=1, padx=2, sticky=W)
         setup_tooltip(rwnd_speed_control_spinbox, "Speed up/slow down the RWND/FF speed.")
 

--- a/ALT-Scann8-UserInterface.py
+++ b/ALT-Scann8-UserInterface.py
@@ -639,7 +639,7 @@ def wb_red_selection():
     if AWB_enabled.get():  # Do not allow spinbox changes when in auto mode (should not happen as spinbox is readonly)
         return
 
-    GainRed = float(wb_red_spinbox.get())
+    GainRed = float(wb_red_str.get())
     SessionData["GainRed"] = GainRed
 
     if not SimulatedRun and not AWB_enabled.get() and not CameraDisabled:
@@ -658,7 +658,7 @@ def wb_blue_selection():
     if AWB_enabled.get():  # Do not allow spinbox changes when in auto mode (should not happen as spinbox is readonly)
         return
 
-    GainBlue = float(wb_blue_spinbox.get())
+    GainBlue = float(wb_blue_str.get())
     SessionData["GainBlue"] = GainBlue
 
     if not SimulatedRun and not AWB_enabled.get() and not CameraDisabled:
@@ -678,9 +678,9 @@ def wb_spinbox_auto():
     if not ExpertMode:
         return
 
-    SessionData["CurrentAwbAuto"] = str(AWB_enabled.get())
-    SessionData["GainRed"] = str(GainRed)
-    SessionData["GainBlue"] = str(GainBlue)
+    SessionData["CurrentAwbAuto"] = AWB_enabled.get()
+    SessionData["GainRed"] = GainRed
+    SessionData["GainBlue"] = GainBlue
 
     if AWB_enabled.get():
         awb_red_wait_checkbox.config(state=NORMAL)
@@ -700,8 +700,8 @@ def wb_spinbox_auto():
             camera_colour_gains = metadata["ColourGains"]
             GainRed = camera_colour_gains[0]
             GainBlue = camera_colour_gains[1]
-            wb_red_spinbox.config(text=str(round(GainRed, 1)))
-            wb_blue_spinbox.config(text=str(round(GainBlue, 1)))
+            wb_red_str.set(str(GainRed))
+            wb_blue_str.set(str(GainBlue))
             camera.set_controls({"AwbEnable": 0})
 
     arrange_widget_state(AWB_enabled.get(), [wb_blue_btn, wb_blue_spinbox])
@@ -1857,7 +1857,6 @@ def capture(mode):
             aux_gain_red = camera_colour_gains[0]
             aux_gain_blue = camera_colour_gains[1]
             # Same as for exposure, difference allowed is a percentage of the maximum value
-            #if abs(aux_gain_red-PreviousGainRed) >= 0.5 or abs(aux_gain_blue-PreviousGainBlue) >= 0.5:
             if abs(aux_gain_red-PreviousGainRed) >= (MatchWaitMargin * Tolerance_AWB/100) or \
                abs(aux_gain_blue-PreviousGainBlue) >= (MatchWaitMargin * Tolerance_AWB/100):
                 if (wait_loop_count % 10 == 0):
@@ -2305,7 +2304,7 @@ def onesec_periodic_checks():  # Update RPi temperature every 10 seconds
     temperature_check()
     preview_check()
 
-    print(f"exposure_value: {exposure_value.get()}")
+    print(f"exposure_value: {exposure_value.get()}, wb_red_str: {wb_red_str.get()}, wb_blue_str: {wb_blue_str.get()}")
 
     win.after(1000, onesec_periodic_checks)
 
@@ -3066,8 +3065,7 @@ def create_widgets():
     global frame_extra_steps_spinbox, frame_extra_steps_str
     global scan_speed_str, ScanSpeed, scan_speed_spinbox
     global exposure_spinbox, exposure_value
-    global wb_red_spinbox, wb_red_str
-    global wb_blue_spinbox, wb_blue_str
+    global wb_red_spinbox, wb_blue_spinbox, wb_red_str, wb_blue_str
     global match_wait_margin_spinbox, match_wait_margin_str
     global stabilization_delay_spinbox, stabilization_delay_str
     global sharpness_control_spinbox, sharpness_control_str

--- a/ALT-Scann8-UserInterface.py
+++ b/ALT-Scann8-UserInterface.py
@@ -757,7 +757,7 @@ def manual_scan_take_snap():
         time.sleep(0.2)
 
 
-def match_wait_margin_selection(updown):
+def match_wait_margin_selection():
     global MatchWaitMargin, match_wait_margin_spinbox
     global wb_red_spinbox
     global SimulatedRun
@@ -2307,7 +2307,7 @@ def onesec_periodic_checks():  # Update RPi temperature every 10 seconds
     temperature_check()
     preview_check()
 
-    print(f"exposure_value: {exposure_value.get()}, wb_red_str: {wb_red_str.get()}, wb_blue_str: {wb_blue_str.get()}")
+    print(f"exposure_value: {exposure_value.get()}, wb_red_str: {wb_red_str.get()}, wb_blue_str: {wb_blue_str.get()}, match_wait_margin_value: {match_wait_margin_value.get()}")
 
     win.after(1000, onesec_periodic_checks)
 
@@ -2500,7 +2500,7 @@ def load_config_data():
     global TempInFahrenheit
     global temp_in_fahrenheit_checkbox
     global PersistedDataLoaded
-    global MatchWaitMargin, match_wait_margin_str
+    global MatchWaitMargin
     global SharpnessValue, sharpness_control_spinbox
     global CaptureStabilizationDelay, stabilization_delay_str
 
@@ -2515,7 +2515,7 @@ def load_config_data():
         if ExpertMode:
             if 'MatchWaitMargin' in SessionData:
                 MatchWaitMargin = int(SessionData["MatchWaitMargin"])
-                match_wait_margin_str.set(str(MatchWaitMargin))
+                match_wait_margin_value.set(MatchWaitMargin)
             if 'CaptureStabilizationDelay' in SessionData:
                 CaptureStabilizationDelay = float(SessionData["CaptureStabilizationDelay"])
                 stabilization_delay_str.set(str(round(CaptureStabilizationDelay * 1000)))
@@ -3072,7 +3072,7 @@ def create_widgets():
     global scan_speed_str, ScanSpeed, scan_speed_spinbox
     global exposure_spinbox, exposure_value
     global wb_red_spinbox, wb_blue_spinbox, wb_red_str, wb_blue_str
-    global match_wait_margin_spinbox, match_wait_margin_str
+    global match_wait_margin_spinbox, match_wait_margin_value
     global stabilization_delay_spinbox, stabilization_delay_str
     global sharpness_control_spinbox, sharpness_control_str
     global rwnd_speed_control_spinbox, rwnd_speed_control_str
@@ -3519,13 +3519,11 @@ def create_widgets():
                                          width=15, font=("Arial", FontSize-1))
         match_wait_margin_label.grid(row=4, column=0, padx=5, pady=1, sticky=E)
 
-        match_wait_margin_str = tk.StringVar(value=str(MatchWaitMargin))
-
-        match_wait_margin_selection_aux = exp_wb_frame.register(match_wait_margin_selection)
+        match_wait_margin_value = tk.IntVar(value=MatchWaitMargin)
         match_wait_margin_spinbox = tk.Spinbox(
             exp_wb_frame,
-            command=(match_wait_margin_selection_aux, '%d'), width=8,
-            textvariable=match_wait_margin_str, from_=0, to=100, increment=5, font=("Arial", FontSize-1))
+            command=match_wait_margin_selection, width=8,
+            textvariable=match_wait_margin_value, from_=0, to=100, increment=5, font=("Arial", FontSize-1))
         match_wait_margin_spinbox.grid(row=4, column=1, padx=5, pady=1, sticky=W)
         setup_tooltip(match_wait_margin_spinbox, "When automatic exposure/WB enabled, and stabilization wait is selected, select the level to match before terminating wait.")
 

--- a/ALT-Scann8-UserInterface.py
+++ b/ALT-Scann8-UserInterface.py
@@ -766,26 +766,26 @@ def match_wait_margin_selection():
     MatchWaitMargin = int(match_wait_margin_spinbox.get())
     SessionData["MatchWaitMargin"] = MatchWaitMargin
 
-def stabilization_delay_selection(updown):
+def stabilization_delay_selection():
     global stabilization_delay_label
     global CaptureStabilizationDelay
-    global stabilization_delay_spinbox, stabilization_delay_str
+    global stabilization_delay_spinbox
     global SimulatedRun
 
     if not ExpertMode:
         return
 
-    CaptureStabilizationDelay = int(stabilization_delay_spinbox.get())/1000
+    CaptureStabilizationDelay = stabilization_delay_value.get()/1000
     SessionData["CaptureStabilizationDelay"] = str(CaptureStabilizationDelay)
 
 
 def stabilization_delay_spinbox_focus_out(event):
     global stabilization_delay_label
     global CaptureStabilizationDelay
-    global stabilization_delay_spinbox, stabilization_delay_str
+    global stabilization_delay_spinbox
     global SimulatedRun
 
-    CaptureStabilizationDelay = int(stabilization_delay_spinbox.get())/1000
+    CaptureStabilizationDelay = stabilization_delay_value.get()/1000
     SessionData["CaptureStabilizationDelay"] = str(CaptureStabilizationDelay)
 
 
@@ -886,36 +886,36 @@ def min_frame_steps_spinbox_auto():
     send_arduino_command(CMD_SET_MIN_FRAME_STEPS, 0 if auto_framesteps_enabled.get() else MinFrameSteps)
 
 
-def frame_fine_tune_selection(updown):
-    global frame_fine_tune_spinbox, frame_fine_tune_str
+def frame_fine_tune_selection():
+    global frame_fine_tune_spinbox
     global FrameFineTune
-    FrameFineTune = int(frame_fine_tune_spinbox.get())
+    FrameFineTune = frame_fine_tune_value.get()
     SessionData["FrameFineTune"] = FrameFineTune
     SessionData["FrameFineTune" + SessionData["FilmType"]] = FrameFineTune
     send_arduino_command(CMD_SET_FRAME_FINE_TUNE, FrameFineTune)
 
 
 def frame_fine_tune_spinbox_focus_out(event):
-    global frame_fine_tune_spinbox, frame_fine_tune_str
+    global frame_fine_tune_spinbox
     global FrameFineTune
-    FrameFineTune = int(frame_fine_tune_spinbox.get())
+    FrameFineTune = frame_fine_tune_value.get()
     SessionData["FrameFineTune"] = FrameFineTune
     SessionData["FrameFineTune" + SessionData["FilmType"]] = FrameFineTune
     send_arduino_command(CMD_SET_FRAME_FINE_TUNE, FrameFineTune)
 
 
-def frame_extra_steps_selection(updown):
-    global frame_extra_steps_spinbox, frame_extra_steps_str
+def frame_extra_steps_selection():
+    global frame_extra_steps_spinbox
     global FrameExtraSteps
-    FrameExtraSteps = int(frame_extra_steps_spinbox.get())
+    FrameExtraSteps = frame_extra_steps_value.get()
     SessionData["FrameExtraSteps"] = FrameExtraSteps
     send_arduino_command(CMD_SET_EXTRA_STEPS, FrameExtraSteps)
 
 
 def frame_extra_steps_spinbox_focus_out(event):
-    global frame_extra_steps_spinbox, frame_extra_steps_str
+    global frame_extra_steps_spinbox
     global FrameExtraSteps
-    FrameExtraSteps = int(frame_extra_steps_spinbox.get())
+    FrameExtraSteps = frame_extra_steps_value.get()
     SessionData["FrameExtraSteps"] = FrameExtraSteps
     send_arduino_command(CMD_SET_EXTRA_STEPS, FrameExtraSteps)
 
@@ -956,7 +956,7 @@ def pt_level_spinbox_auto():
     send_arduino_command(CMD_SET_PT_LEVEL, 0 if auto_pt_level_enabled.get() else PTLevel)
 
 
-def scan_speed_selection(updown):
+def scan_speed_selection():
     global scan_speed_spinbox, scan_speed_label_str
     global ScanSpeed
     ScanSpeed = int(scan_speed_spinbox.get())
@@ -2313,7 +2313,10 @@ def onesec_periodic_checks():  # Update RPi temperature every 10 seconds
     preview_check()
 
     print(f"exposure_value: {exposure_value.get()}, wb_red_str: {wb_red_str.get()}, wb_blue_str: {wb_blue_str.get()}, "
-          f"match_wait_margin_value: {match_wait_margin_value.get()}, min_frame_steps_value: {min_frame_steps_value.get()}")
+          f"match_wait_margin_value: {match_wait_margin_value.get()}, min_frame_steps_value: {min_frame_steps_value.get()}, "
+          f"pt_level_value: {pt_level_value.get()}, frame_fine_tune_value: {frame_fine_tune_value.get()}, "
+          f"frame_extra_steps_value: {frame_extra_steps_value.get()}, scan_speed_value: {scan_speed_value.get()}, "
+          f"stabilization_delay_value: {stabilization_delay_value.get()}")
 
     win.after(1000, onesec_periodic_checks)
 
@@ -2507,7 +2510,7 @@ def load_config_data():
     global PersistedDataLoaded
     global MatchWaitMargin
     global SharpnessValue, sharpness_control_spinbox
-    global CaptureStabilizationDelay, stabilization_delay_str
+    global CaptureStabilizationDelay
 
     for item in SessionData:
         logging.debug("%s=%s", item, str(SessionData[item]))
@@ -2523,7 +2526,7 @@ def load_config_data():
                 match_wait_margin_value.set(MatchWaitMargin)
             if 'CaptureStabilizationDelay' in SessionData:
                 CaptureStabilizationDelay = float(SessionData["CaptureStabilizationDelay"])
-                stabilization_delay_str.set(str(round(CaptureStabilizationDelay * 1000)))
+                stabilization_delay_value.set(round(CaptureStabilizationDelay * 1000))
 
         if ExperimentalMode:
             if 'SharpnessValue' in SessionData:
@@ -2565,10 +2568,9 @@ def load_session_data():
     global awb_red_wait_checkbox, awb_blue_wait_checkbox
     global auto_exp_wait_checkbox
     global PersistedDataLoaded
-    global frame_fine_tune_str
-    global MinFrameSteps, MinFrameStepsS8, MinFrameStepsR8, FrameFineTune, FrameExtraSteps, frame_extra_steps_str
+    global MinFrameSteps, MinFrameStepsS8, MinFrameStepsR8, FrameFineTune, FrameExtraSteps
     global PTLevel, PTLevelS8, PTLevelR8
-    global ScanSpeed, scan_speed_str
+    global ScanSpeed
     global hdr_capture_active_checkbox, HdrCaptureActive
     global hdr_viewx4_active_checkbox, HdrViewX4Active
     global hdr_min_exp, hdr_max_exp, hdr_bracket_width_auto_checkbox
@@ -2736,12 +2738,12 @@ def load_session_data():
                     MinFrameStepsR8 = SessionData["MinFrameStepsR8"]
                 if 'FrameFineTune' in SessionData:
                     FrameFineTune = SessionData["FrameFineTune"]
-                    frame_fine_tune_str.set(str(FrameFineTune))
+                    frame_fine_tune_value.set(FrameFineTune)
                     send_arduino_command(CMD_SET_FRAME_FINE_TUNE, FrameFineTune)
                 if 'FrameExtraSteps' in SessionData:
                     FrameExtraSteps = SessionData["FrameExtraSteps"]
                     FrameExtraSteps = min(FrameExtraSteps, 20)
-                    frame_extra_steps_str.set(str(FrameExtraSteps))
+                    frame_extra_steps_value.set(FrameExtraSteps)
                     send_arduino_command(CMD_SET_EXTRA_STEPS, FrameExtraSteps)
                 if 'PTLevelAuto' in SessionData:
                     auto_pt_level_enabled.set(SessionData["PTLevelAuto"])
@@ -2762,8 +2764,8 @@ def load_session_data():
                 if 'PTLevelR8' in SessionData:
                     PTLevelR8 = SessionData["PTLevelR8"]
                 if 'ScanSpeed' in SessionData:
-                    ScanSpeed = SessionData["ScanSpeed"]
-                    scan_speed_str.set(str(ScanSpeed))
+                    ScanSpeed = int(SessionData["ScanSpeed"])
+                    scan_speed_value.set(ScanSpeed)
                     send_arduino_command(CMD_SET_SCAN_SPEED, ScanSpeed)
 
     # Update widget state whether or not config loaded (to honor app default values)
@@ -3073,17 +3075,17 @@ def create_widgets():
     global focus_lf_btn, focus_up_btn, focus_dn_btn, focus_rt_btn, focus_plus_btn, focus_minus_btn
     global draw_capture_canvas
     global hdr_btn
-    global min_frame_steps_value, frame_fine_tune_str
+    global min_frame_steps_value, frame_fine_tune_value
     global MinFrameSteps
     global pt_level_spinbox
     global PTLevel
     global min_frame_steps_spinbox, frame_fine_tune_spinbox, pt_level_spinbox, pt_level_value
-    global frame_extra_steps_spinbox, frame_extra_steps_str
-    global scan_speed_str, ScanSpeed, scan_speed_spinbox
+    global frame_extra_steps_spinbox, frame_extra_steps_value
+    global ScanSpeed, scan_speed_spinbox, scan_speed_value
     global exposure_spinbox, exposure_value
     global wb_red_spinbox, wb_blue_spinbox, wb_red_str, wb_blue_str
     global match_wait_margin_spinbox, match_wait_margin_value
-    global stabilization_delay_spinbox, stabilization_delay_str
+    global stabilization_delay_spinbox, stabilization_delay_value
     global sharpness_control_spinbox, sharpness_control_str
     global rwnd_speed_control_spinbox, rwnd_speed_control_str
     global Manual_scan_activated, ManualScanEnabled, manual_scan_advance_fraction_5_btn, manual_scan_advance_fraction_20_btn, manual_scan_take_snap_btn
@@ -3595,13 +3597,9 @@ def create_widgets():
                                          text='Fine tune:',
                                          font=("Arial", FontSize-1))
         frame_fine_tune_label.grid(row=2, column=0, padx=2, pady=3, sticky=E)
-        frame_fine_tune_str = tk.StringVar(value=str(FrameFineTune))
-        frame_fine_tune_selection_aux = frame_alignment_frame.register(
-            frame_fine_tune_selection)
-        frame_fine_tune_spinbox = tk.Spinbox(
-            frame_alignment_frame,
-            command=(frame_fine_tune_selection_aux, '%d'), width=8,
-            textvariable=frame_fine_tune_str, from_=5, to=95, increment=5, font=("Arial", FontSize-1))
+        frame_fine_tune_value = tk.IntVar(value=FrameFineTune)
+        frame_fine_tune_spinbox = tk.Spinbox(frame_alignment_frame, command=frame_fine_tune_selection, width=8,
+                        textvariable=frame_fine_tune_value, from_=5, to=95, increment=5, font=("Arial", FontSize-1))
         frame_fine_tune_spinbox.grid(row=2, column=1, padx=2, pady=3, sticky=W)
         setup_tooltip(frame_fine_tune_spinbox, "Fine tune of frame detection: Can move the frame slightly up or down at detection time.")
         frame_fine_tune_spinbox.bind("<FocusOut>", frame_fine_tune_spinbox_focus_out)
@@ -3610,13 +3608,9 @@ def create_widgets():
                                          text='Extra Steps:',
                                          font=("Arial", FontSize-1))
         frame_extra_steps_label.grid(row=3, column=0, padx=2, pady=3, sticky=E)
-        frame_extra_steps_str = tk.StringVar(value=str(FrameExtraSteps))
-        frame_extra_steps_selection_aux = frame_alignment_frame.register(
-            frame_extra_steps_selection)
-        frame_extra_steps_spinbox = tk.Spinbox(
-            frame_alignment_frame,
-            command=(frame_extra_steps_selection_aux, '%d'), width=8,
-            textvariable=frame_extra_steps_str, from_=-30, to=30, font=("Arial", FontSize-1))
+        frame_extra_steps_value = tk.IntVar(value=FrameExtraSteps)
+        frame_extra_steps_spinbox = tk.Spinbox(frame_alignment_frame, command=frame_extra_steps_selection, width=8,
+                        textvariable=frame_extra_steps_value, from_=-30, to=30, font=("Arial", FontSize-1))
         frame_extra_steps_spinbox.grid(row=3, column=1, padx=2, pady=3, sticky=W)
         setup_tooltip(frame_extra_steps_spinbox, "Unconditionally advances the frame n steps after detection. Can be useful only in rare cases, 'Fine tune' should be enough.")
         frame_extra_steps_spinbox.bind("<FocusOut>", frame_extra_steps_spinbox_focus_out)
@@ -3631,30 +3625,21 @@ def create_widgets():
                                          text='Scan Speed:',
                                          font=("Arial", FontSize-1))
         scan_speed_label.grid(row=0, column=0, padx=3, pady=(20, 10), sticky=E)
-        scan_speed_str = tk.StringVar(value=str(ScanSpeed))
-        scan_speed_selection_aux = speed_quality_frame.register(
-            scan_speed_selection)
-        scan_speed_spinbox = tk.Spinbox(
-            speed_quality_frame,
-            command=(scan_speed_selection_aux, '%d'), width=3,
-            textvariable=scan_speed_str, from_=1, to=10, font=("Arial", FontSize-1))
+        scan_speed_value = tk.IntVar(value=ScanSpeed)
+        scan_speed_spinbox = tk.Spinbox(speed_quality_frame, command=scan_speed_selection, width=3,
+                    textvariable=scan_speed_value, from_=1, to=10, font=("Arial", FontSize-1))
         scan_speed_spinbox.grid(row=0, column=1, padx=4, pady=4, sticky=W)
         setup_tooltip(scan_speed_spinbox, "Select scan speed from 1 (slowest) to 10 (fastest).A speed of 5 is usually a good compromise between speed and good frame position detection.")
         scan_speed_spinbox.bind("<FocusOut>", scan_speed_spinbox_focus_out)
-        scan_speed_selection('down')
 
         # Display entry to adjust capture stabilization delay (100 ms by default)
         stabilization_delay_label = tk.Label(speed_quality_frame,
                                          text='Stabilization\ndelay (ms):',
                                          font=("Arial", FontSize-1))
         stabilization_delay_label.grid(row=1, column=0, padx=4, pady=4, sticky=E)
-        stabilization_delay_str = tk.StringVar(value=str(round(CaptureStabilizationDelay*1000)))
-        stabilization_delay_selection_aux = speed_quality_frame.register(
-            stabilization_delay_selection)
-        stabilization_delay_spinbox = tk.Spinbox(
-            speed_quality_frame,
-            command=(stabilization_delay_selection_aux, '%d'), width=4,
-            textvariable=stabilization_delay_str, from_=0, to=1000, increment=10, font=("Arial", FontSize-1))
+        stabilization_delay_value = tk.IntVar(value=round(CaptureStabilizationDelay*1000))
+        stabilization_delay_spinbox = tk.Spinbox(speed_quality_frame, command=stabilization_delay_selection, width=4,
+                    textvariable=stabilization_delay_value, from_=0, to=1000, increment=10, font=("Arial", FontSize-1))
         stabilization_delay_spinbox.grid(row=1, column=1, padx=4, sticky='W')
         setup_tooltip(stabilization_delay_spinbox, "Delay between frame detection and snapshot trigger. 100ms is a good compromise, lower values might cause blurry captures.")
         stabilization_delay_spinbox.bind("<FocusOut>", stabilization_delay_spinbox_focus_out)


### PR DESCRIPTION
- Normalize handling of values from widgets
  - Use the correct variable type (IntVar, DoubleVar, StringVar)
  - Add validation functions
  - Remove all useless convestions string to number
- Not directly related, but exposure field not is displayed using milliseconds (before it was an invented conversion)
- Bugfix: Sometimes there were errors while exiting the application due to pending 'after' callbacks. Now flag is added to indicate app is exiting to allow them to die gracefully (this implies a 3 seconds delay to give enough time to terminate).