### PR TITLE
ALT-Scann8 1.10.17

### DIFF
--- a/ALT-Scann8-UserInterface.py
+++ b/ALT-Scann8-UserInterface.py
@@ -20,8 +20,8 @@ __copyright__ = "Copyright 2022-24, Juan Remirez de Esparza"
 __credits__ = ["Juan Remirez de Esparza"]
 __license__ = "MIT"
 __module__ = "ALT-Scann8"
-__version__ = "1.10.2"
-__date__ = "2024-02-25"
+__version__ = "1.10.3"
+__date__ = "2024-02-26"
 __version_highlight__ = "Fix disable tooltips"
 __maintainer__ = "Juan Remirez de Esparza"
 __email__ = "jremirez@hotmail.com"
@@ -4188,6 +4188,7 @@ def main(argv):
     global CameraDisabled, DisableThreads
     global ForceSmallSize, ForceBigSize
 
+    go_disable_tooptips = False
 
     opts, args = getopt.getopt(argv, "sexl:ph12nt")
 

--- a/ALT-Scann8-UserInterface.py
+++ b/ALT-Scann8-UserInterface.py
@@ -20,9 +20,9 @@ __copyright__ = "Copyright 2022-24, Juan Remirez de Esparza"
 __credits__ = ["Juan Remirez de Esparza"]
 __license__ = "MIT"
 __module__ = "ALT-Scann8"
-__version__ = "1.10.3"
-__date__ = "2024-02-26"
-__version_highlight__ = "Fix disable tooltips"
+__version__ = "1.10.14"
+__date__ = "2024-03-02"
+__version_highlight__ = "Customizable font size + Scrollable main window"
 __maintainer__ = "Juan Remirez de Esparza"
 __email__ = "jremirez@hotmail.com"
 __status__ = "Development"
@@ -70,6 +70,7 @@ except ImportError:
 import threading
 import queue
 import cv2
+import re
 
 from camera_resolutions import CameraResolutions
 from dynamic_spinbox import DynamicSpinbox
@@ -80,6 +81,7 @@ from rolling_average import RollingAverage
 win = None
 as_tooltips = None
 ExitingApp = False
+add_vertical_scrollbar = False
 Controller_Id = 0   # 1 - Arduino, 2 - RPi Pico
 FocusState = True
 lastFocus = True
@@ -150,14 +152,16 @@ TopWinX = 0
 TopWinY = 0
 PreviewWinX = 90
 PreviewWinY = 75
-PreviewWidth = 844
-PreviewHeight = 634
+PreviewWidth = 0
+PreviewHeight = 0
+FilmHoleY_Top = 0
+FilmHoleY_Bottom = 0
+FilmHoleHeightTop = 0
+FilmHoleHeightBottom = 0
 DeltaX = 0
 DeltaY = 0
 WinInitDone = False
-BigSize = True
-ForceSmallSize = False
-ForceBigSize = False
+FontSize = 11
 FolderProcess = 0
 LoggingMode = "INFO"
 LogLevel = 0
@@ -177,8 +181,6 @@ ZoomSize = 0
 simulated_captured_frame_list = [None] * 1000
 simulated_capture_image = ''
 simulated_images_in_list = 0
-FilmHoleY1 = 246 if BigSize else 196
-FilmHoleY2 = 246 if BigSize else 196
 
 # Commands (RPI to Arduino)
 CMD_VERSION_ID = 1
@@ -229,9 +231,10 @@ RSP_FILM_FORWARD_ENDED = 89
 ExpertMode = True
 ExperimentalMode = True
 PlotterMode = True
+keep_control_widgets_enabled = False
 plotter_canvas = None
-plotter_width = 240
-plotter_height = 180
+plotter_width = 20
+plotter_height = 10
 PrevPTValue = 0
 PrevThresholdLevel = 0
 MaxPT = 100
@@ -477,10 +480,8 @@ def set_focus_zoom():
     global FocusZoomActive
 
     if real_time_zoom.get():
-        real_time_zoom_checkbox.config(fg="white")  # Change background color and text color when checked
         real_time_display_checkbox.config(state=DISABLED)
     else:
-        real_time_zoom_checkbox.config(fg="black")  # Change back to default colors when unchecked
         real_time_display_checkbox.config(state=NORMAL)
 
     if not SimulatedRun and not CameraDisabled:
@@ -613,6 +614,35 @@ def set_new_folder():
         SessionData["CurrentFrame"] = str(CurrentFrame)
 
 
+def get_last_frame_dismiss():
+    last_frame_dlg.grab_release()
+    last_frame_dlg.destroy()
+
+
+def get_last_frame(last_frame):
+    global last_frame_dlg
+    last_frame_dlg = tk.Toplevel(win)
+    last_frame_dlg.title("Last frame")
+    #last_frame_dlg.geometry(f"300x100")
+    last_frame_dlg.rowconfigure(0, weight=1)
+    last_frame_dlg.columnconfigure(0, weight=1)
+
+    last_frame_label = tk.Label(last_frame_dlg, text="Enter number of last captured frame")
+    last_frame_label.grid(row=0, column=0, columnspan=2, sticky='nsew', padx=10, pady=5)
+    last_frame_int = tk.IntVar(value=0)
+    last_frame_int.set(last_frame)
+    last_frame_entry = tk.Entry(last_frame_dlg, textvariable=last_frame_int, width=6, font=("Arial", FontSize), justify="right")
+    last_frame_entry.grid(row=1, column=0, columnspan=2, padx=10, pady=5)
+    last_frame_ok_btn = tk.Button(last_frame_dlg, text="OK", command=get_last_frame_dismiss)
+    last_frame_ok_btn.grid(row=2, column=0, padx=10, pady=5)
+    last_frame_dlg.protocol("WM_DELETE_WINDOW", get_last_frame_dismiss)  # intercept close button
+    last_frame_dlg.transient(win)  # dialog window is related to main
+    last_frame_dlg.wait_visibility()  # can't grab until window appears, so we wait
+    last_frame_dlg.grab_set()  # ensure all input goes to our window
+    last_frame_dlg.wait_window()  # block until window is destroyed
+    return last_frame_int.get()
+
+
 def set_existing_folder():
     global CurrentDir, CurrentFrame
 
@@ -624,13 +654,18 @@ def set_existing_folder():
     if not NewDir:
         return
 
+    # Get number of files and highest frame number in selected folder
     filecount = 0
+    last_frame = 0
     for name in os.listdir(NewDir):
         if os.path.isfile(os.path.join(NewDir, name)):
+            # Extract frame number using regular expression
+            frame_number = re.findall(r'\d+', name)
+            last_frame = max(last_frame, int(frame_number[0]))   # Only one number in the filename, so we take the first
             filecount += 1
 
-    current_frame_str = tk.simpledialog.askstring(title="Enter number of last captured frame",
-                                                  prompt="Last frame captured?")
+    current_frame_str = str(get_last_frame(last_frame))
+
     if current_frame_str is None:
         current_frame_str = '0'
 
@@ -638,10 +673,10 @@ def set_existing_folder():
         current_frame_str = '0'
     NewCurrentFrame = int(current_frame_str)
 
-    if filecount > 0 and NewCurrentFrame <= filecount:
+    if filecount > 0 and NewCurrentFrame < last_frame:
         confirm = tk.messagebox.askyesno(title='Files exist in target folder',
                                          message=f"Newly selected folder already contains {filecount} files."
-                                         f"\r\nSetting {NewCurrentFrame} as initial frame will overwrite some of them."
+                                         f"\r\nSetting {NewCurrentFrame} as last captured frame will overwrite {last_frame-NewCurrentFrame} frames."
                                          f"Are you sure you want to continue?")
     else:
         confirm = True
@@ -666,10 +701,14 @@ def set_auto_wb():
     SessionData["GainBlue"] = wb_blue_value.get()
 
     if AWB_enabled.get():
+        auto_wb_red_btn.config(text="AWB Red:")
+        auto_wb_blue_btn.config(text="AWB Blue:")
         auto_wb_wait_btn.config(state=NORMAL)
         if not SimulatedRun and not CameraDisabled:
             camera.set_controls({"AwbEnable": True})
     else:
+        auto_wb_red_btn.config(text="WB Red:")
+        auto_wb_blue_btn.config(text="WB Blue:")
         auto_wb_wait_btn.config(state=DISABLED)
         if not SimulatedRun and not CameraDisabled:
             # Do not retrieve current gain values from Camera (capture_metadata) to prevent conflicts
@@ -754,64 +793,51 @@ def frame_extra_steps_selection():
 
 def button_status_change_except(except_button, active):
     global button_lock_counter
+    general_widget_list=[SingleStep_btn,Snapshot_btn,AdvanceMovie_btn,Rewind_btn,FastForward_btn,negative_image_checkbox,
+                        Exit_btn,film_type_S8_rb,film_type_R8_rb,file_type_dropdown,new_folder_btn,real_time_display_checkbox,
+                        resolution_label,resolution_dropdown,file_type_label,file_type_dropdown,existing_folder_btn, hdr_capture_active_checkbox]
+    control_widget_list = [auto_exposure_btn, exposure_spinbox, auto_exposure_wait_btn, auto_wb_red_btn, wb_red_spinbox,
+                           auto_wb_wait_btn, auto_wb_blue_btn, wb_blue_spinbox, match_wait_margin_spinbox,
+                           AeConstraintMode_dropdown, AeMeteringMode_dropdown, AeExposureMode_dropdown,
+                           AwbMode_dropdown, brightness_spinbox, contrast_spinbox, saturation_spinbox,
+                           analogue_gain_spinbox, sharpness_spinbox, exposure_compensation_spinbox,
+                           steps_per_frame_spinbox, pt_level_spinbox, frame_fine_tune_spinbox,
+                           frame_extra_steps_spinbox, scan_speed_spinbox, stabilization_delay_spinbox,
+                           pt_level_btn, steps_per_frame_btn,hdr_bracket_width_auto_checkbox]
+    hdr_widget_list = [hdr_min_exp_spinbox, hdr_max_exp_spinbox, hdr_bracket_width_spinbox,
+                       hdr_bracket_shift_spinbox,hdr_merge_in_place_checkbox]
+    experimental_widget_list = [RetreatMovie_btn,Free_btn,Manual_scan_checkbox]
 
     if active:
         button_lock_counter += 1
     else:
         button_lock_counter -= 1
+
     if button_lock_counter > 1 or (not active and button_lock_counter > 0):
         return
-    if except_button != SingleStep_btn:
-        SingleStep_btn.config(state=DISABLED if active else NORMAL)
-    if except_button != Snapshot_btn:
-        Snapshot_btn.config(state=DISABLED if active else NORMAL)
-    if except_button != AdvanceMovie_btn:
-        AdvanceMovie_btn.config(state=DISABLED if active else NORMAL)
-    if except_button != Rewind_btn:
-        Rewind_btn.config(state=DISABLED if active else NORMAL)
-    if except_button != FastForward_btn:
-        FastForward_btn.config(state=DISABLED if active else NORMAL)
-    if except_button != negative_image_checkbox:
-        negative_image_checkbox.config(state=DISABLED if active else NORMAL)
-    if except_button != Start_btn and not PiCam2PreviewEnabled:
-        Start_btn.config(state=DISABLED if active else NORMAL)
-    if except_button != Exit_btn:
-        Exit_btn.config(state=DISABLED if active else NORMAL)
-    if except_button != film_type_S8_rb:
-        film_type_S8_rb.config(state=DISABLED if active else NORMAL)
-    if except_button != film_type_R8_rb:
-        film_type_R8_rb.config(state=DISABLED if active else NORMAL)
-    '''
-    if except_button != file_type_jpg_rb:
-        file_type_jpg_rb.config(state=DISABLED if active else NORMAL)
-    if except_button != file_type_png_rb:
-        file_type_png_rb.config(state=DISABLED if active else NORMAL)
-    '''
-    if except_button != file_type_dropdown:
-        file_type_dropdown.config(state=DISABLED if active else NORMAL)
+
+    for widget in general_widget_list:
+        if except_button != widget:
+            widget.config(state=DISABLED if active else NORMAL)
+
+    if not keep_control_widgets_enabled:
+        for widget in control_widget_list:
+            if except_button != widget:
+                widget.config(state=DISABLED if active else NORMAL)
+        if hdr_capture_active:
+            for widget in hdr_widget_list:
+                if except_button != widget:
+                    widget.config(state=DISABLED if active else NORMAL)
+
     if ExperimentalMode:
-        if except_button != RetreatMovie_btn:
-            RetreatMovie_btn.config(state=DISABLED if active else NORMAL)
-        if except_button != Free_btn:
-            Free_btn.config(state=DISABLED if active else NORMAL)
-        if except_button != hdr_capture_active_checkbox:
-            hdr_capture_active_checkbox.config(state=DISABLED if active else NORMAL)
-    if except_button != new_folder_btn:
-        new_folder_btn.config(state=DISABLED if active else NORMAL)
-    if except_button != real_time_display_checkbox:
-        real_time_display_checkbox.config(state=DISABLED if active else NORMAL)
+        for widget in experimental_widget_list:
+            if except_button != widget:
+                widget.config(state=DISABLED if active else NORMAL)
+
     if except_button != real_time_zoom_checkbox:
         real_time_zoom_checkbox.config(state=NORMAL if real_time_display.get() else DISABLED)
-    if except_button != resolution_label:
-        resolution_label.config(state=DISABLED if active else NORMAL)
-    if except_button != resolution_dropdown:
-        resolution_dropdown.config(state=DISABLED if active else NORMAL)
-    if except_button != file_type_label:
-        file_type_label.config(state=DISABLED if active else NORMAL)
-    if except_button != file_type_dropdown:
-        file_type_dropdown.config(state=DISABLED if active else NORMAL)
-    if except_button != existing_folder_btn:
-        existing_folder_btn.config(state=DISABLED if active else NORMAL)
+    if except_button != Start_btn and not PiCam2PreviewEnabled:
+        Start_btn.config(state=DISABLED if active else NORMAL)
 
 
 def advance_movie(from_arduino = False):
@@ -1184,7 +1210,7 @@ def switch_hdr_capture():
     hdr_set_controls()
     if HdrCaptureActive:    # If HDR enabled, handle automatic control settings for widgets
         max_inactivity_delay = max_inactivity_delay * 2
-        arrange_widget_state(hdr_bracket_auto.get(), [hdr_min_exp_spinbox, hdr_max_exp_spinbox, hdr_bracket_width_auto_checkbox])
+        arrange_widget_state(hdr_bracket_auto.get(), [hdr_min_exp_spinbox, hdr_max_exp_spinbox])
     else:    # If disabling HDR, need to set standard exposure as set in UI
         max_inactivity_delay = int(max_inactivity_delay / 2)
         if AE_enabled.get():  # Automatic mode
@@ -1211,23 +1237,15 @@ def switch_hdr_viewx4():
 
 def set_negative_image():
     SessionData["NegativeCaptureActive"] = negative_image.get()
-    if negative_image.get():
-        negative_image_checkbox.config(fg="white")  # Change background color and text color when checked
-    else:
-        negative_image_checkbox.config(fg="black")  # Change back to default colors when unchecked
 
 
 def toggle_ui_size():
-    global app_height
+    global app_width, app_height
 
     if toggle_ui_small.get():
-        app_height -= 290 if BigSize else 230
-        expert_frame.pack_forget()
-        experimental_frame.pack_forget()
+        extended_frame.pack_forget()
     else:
-        app_height += 290 if BigSize else 230
-        expert_frame.pack(side=LEFT, padx=5, ipadx=5, pady=5, fill='both', expand=True)
-        experimental_frame.pack(side=LEFT, padx=5, ipadx=5, pady=5, fill='both', expand=True)
+        extended_frame.pack(side=LEFT, padx=10, expand=True, fill=tk.Y, anchor="center")
     # Prevent window resize
     win.minsize(app_width, app_height)
     win.maxsize(app_width, app_height)
@@ -1241,10 +1259,8 @@ def toggle_ui_size():
 def set_real_time_display():
     if real_time_display.get():
         logging.debug("Real time display enabled")
-        real_time_display_checkbox.config(fg="white")  # Change background color and text color when checked
     else:
         logging.debug("Real time display disabled")
-        real_time_display_checkbox.config(fg="black")  # Change background color and text color when checked
     if not SimulatedRun and not CameraDisabled:
         if real_time_display.get():
             if camera._preview:
@@ -1269,7 +1285,7 @@ def set_real_time_display():
 
 
 def set_s8():
-    global FilmHoleY1, FilmHoleY2
+    global PreviewHeight, FilmHoleY_Top, FilmHoleY_Bottom
 
     SessionData["FilmType"] = "S8"
     time.sleep(0.2)
@@ -1282,11 +1298,11 @@ def set_s8():
     if ExpertMode:
         pt_level_value.set(PTLevel)
         steps_per_frame_value.set(MinFrameSteps)
-    # Set reference film holes
-    FilmHoleY1 = 246 if BigSize else 196
-    FilmHoleY2 = 246 if BigSize else 196
-    film_hole_frame_1.place(x=0, y=FilmHoleY2, height=150 if BigSize else 130)
-    film_hole_frame_2.place(x=0, y=FilmHoleY2, height=150 if BigSize else 130)
+    # Size and position of hole markers
+    FilmHoleY_Top = int(PreviewHeight / 2.6)
+    FilmHoleY_Bottom = FilmHoleY_Top
+    film_hole_frame_top.place(x=0, y=FilmHoleY_Top, height=FilmHoleHeightTop)
+    film_hole_frame_bottom.place(x=0, y=FilmHoleY_Bottom, height=FilmHoleHeightBottom)
     if not SimulatedRun:
         send_arduino_command(CMD_SET_SUPER_8)
         send_arduino_command(CMD_SET_PT_LEVEL, 0 if auto_pt_level_enabled.get() else PTLevel)
@@ -1294,7 +1310,8 @@ def set_s8():
 
 
 def set_r8():
-    global film_hole_frame_1, film_hole_frame_2
+    global film_hole_frame_top, film_hole_frame_bottom
+    global PreviewHeight, FilmHoleY_Top, FilmHoleY_Bottom, FilmHoleHeightTop, FilmHoleHeightBottom
 
     SessionData["FilmType"] = "R8"
     time.sleep(0.2)
@@ -1307,11 +1324,11 @@ def set_r8():
     if ExpertMode:
         pt_level_value.set(PTLevel)
         steps_per_frame_value.set(MinFrameSteps)
-    # Set reference film holes
-    FilmHoleY1 = 6 if BigSize else 6
-    FilmHoleY2 = 526 if BigSize else 366
-    film_hole_frame_1.place(x=0, y=FilmHoleY1, height=130 if BigSize else 70)
-    film_hole_frame_2.place(x=0, y=FilmHoleY2, height=110 if BigSize else 130)
+    # Size and position of hole markers
+    FilmHoleY_Top = 6
+    FilmHoleY_Bottom = int(PreviewHeight / 1.25)
+    film_hole_frame_top.place(x=0, y=FilmHoleY_Top, height=FilmHoleHeightTop)
+    film_hole_frame_bottom.place(x=0, y=FilmHoleY_Bottom, height=FilmHoleHeightBottom)
     if not SimulatedRun:
         send_arduino_command(CMD_SET_REGULAR_8)
         send_arduino_command(CMD_SET_PT_LEVEL, 0 if auto_pt_level_enabled.get() else PTLevel)
@@ -1741,6 +1758,7 @@ def capture_loop_simulated():
     global simulated_capture_image
     global session_frames
     global disk_space_error_to_notify
+    global ScanStopRequested
 
     if ScanStopRequested:
         stop_scan_simulated()
@@ -1802,7 +1820,7 @@ def capture_loop_simulated():
         # Update Frames per Minute
         scan_period_frames = CurrentFrame - CurrentScanStartFrame
         if FPM_CalculatedValue == -1:  # FPM not calculated yet, display some indication
-            aux_str = ''.join([char*int(scan_period_frames) for char in '.'])
+            aux_str = ''.join([char*int(min(5,scan_period_frames)) for char in '.'])
             Scanned_Images_Fpm_str.set(f"Frames/Min: {aux_str}")
         else:
             FramesPerMinute = FPM_CalculatedValue
@@ -1982,7 +2000,7 @@ def capture_loop():
             # Update Frames per Minute
             scan_period_frames = CurrentFrame - CurrentScanStartFrame
             if FPM_CalculatedValue == -1:   # FPM not calculated yet, display some indication
-                aux_str = ''.join([char * int(scan_period_frames) for char in '.'])
+                aux_str = ''.join([char * int(min(5, scan_period_frames)) for char in '.'])
                 Scanned_Images_Fpm_str.set(f"Frames/Min: {aux_str}")
             else:
                 FramesPerMinute = FPM_CalculatedValue
@@ -2262,7 +2280,7 @@ def load_config_data():
 def arrange_widget_state(disabled, widget_list):
     for widget in widget_list:
         if isinstance(widget, tk.Spinbox):
-            widget.config(state='readonly' if disabled else NORMAL)
+            widget.config(state='readonly' if disabled else NORMAL)     # Used to be readonly instead of disabled
         elif isinstance(widget, tk.OptionMenu) or isinstance(widget, tk.Label) or isinstance(widget, tk.Checkbutton):
             widget.config(state=DISABLED if disabled else NORMAL)
         elif isinstance(widget, tk.Checkbutton):
@@ -2385,6 +2403,7 @@ def load_session_data():
                     if isinstance(aux, str) and (aux == "Auto" or aux == "0") or isinstance(aux, int) and aux == 0:
                         aux = 0
                         AE_enabled.set(True)
+                        set_auto_exposure()
                         auto_exposure_wait_btn.config(state=NORMAL)
                     else:
                         if isinstance(aux, str):
@@ -2457,6 +2476,7 @@ def load_session_data():
                     send_arduino_command(CMD_SET_MIN_FRAME_STEPS, MinFrameSteps)
                 if 'FrameStepsAuto' in SessionData:
                     auto_framesteps_enabled.set(SessionData["FrameStepsAuto"])
+                    steps_per_frame_auto()
                     if auto_framesteps_enabled.get():
                         send_arduino_command(CMD_SET_MIN_FRAME_STEPS, 0)
                     else:
@@ -2476,6 +2496,7 @@ def load_session_data():
                     send_arduino_command(CMD_SET_EXTRA_STEPS, aux)
                 if 'PTLevelAuto' in SessionData:
                     auto_pt_level_enabled.set(SessionData["PTLevelAuto"])
+                    set_auto_pt_level()
                     if auto_pt_level_enabled.get():
                         send_arduino_command(CMD_SET_PT_LEVEL, 0)
                     else:
@@ -2538,8 +2559,8 @@ def load_session_data():
                                                     AeMeteringMode_label, AeMeteringMode_dropdown,
                                                     AeExposureMode_label, AeExposureMode_dropdown,
                                                     AwbMode_label, AwbMode_dropdown])
-        arrange_widget_state(auto_pt_level_enabled.get(), [pt_level_btn, pt_level_spinbox])
-        arrange_widget_state(auto_framesteps_enabled.get(), [steps_per_frame_btn, steps_per_frame_spinbox])
+        arrange_widget_state(auto_pt_level_enabled.get(), [pt_level_spinbox])
+        arrange_widget_state(auto_framesteps_enabled.get(), [steps_per_frame_spinbox])
     if ExperimentalMode:
         hdr_set_controls()
         if HdrCaptureActive:  # If HDR enabled, handle automatic control settings for widgets
@@ -2644,13 +2665,19 @@ def hdr_reinit():
     hdr_rev_exp_list = list(reversed(hdr_exp_list))
 
 
+def on_configure_scrolled_canvas(event):
+    scrolled_canvas.configure(scrollregion=scrolled_canvas.bbox("all"))
+
+
 def create_main_window():
     global win
     global plotter_width, plotter_height
-    global PreviewWinX, PreviewWinY, app_width, app_height, PreviewWidth, PreviewHeight
-    global FontSize, BigSize
+    global PreviewWinX, PreviewWinY, app_width, app_height, original_app_height, PreviewWidth, PreviewHeight
+    global FontSize
     global TopWinX, TopWinY
     global WinInitDone, as_tooltips
+    global FilmHoleY_Top, FilmHoleY_Bottom, FilmHoleHeightTop, FilmHoleHeightBottom
+    global screen_width, screen_height
 
     win = tkinter.Tk()  # creating the main window and storing the window object in 'win'
     if SimulatedRun:
@@ -2659,28 +2686,28 @@ def create_main_window():
         win.title('ALT-Scann8 v' + __version__)  # setting title of the window
     # Get screen size - maxsize gives the usable screen size
     screen_width, screen_height = win.maxsize()
-    # Set plotter default dimensions
-    plotter_width = 240
-    plotter_height = 180
     # Set dimensions of UI elements adapted to screen size
-    if (screen_height >= 1000 and not ForceSmallSize) or ForceBigSize:
-        BigSize = True
-        FontSize = 11
-        PreviewWidth = 844
-        PreviewHeight = int(PreviewWidth/(4/3))
-        app_width = PreviewWidth + 510
-        app_height = PreviewHeight + 50
-        plotter_width += 50
-    else:
-        BigSize = False
+    if screen_height < 1000:
         FontSize = 8
-        PreviewWidth = 650
-        PreviewHeight = int(PreviewWidth/(4/3))
-        app_width = PreviewWidth + 440
-        app_height = PreviewHeight + 50
-        plotter_height -= 55
+    PreviewWidth = 700
+    PreviewHeight = int(PreviewWidth/(4/3))
+    app_width = PreviewWidth + 420
+    app_height = PreviewHeight + 50
+    # Set minimum plotter size, to be adjusted later based on left frame width
+    plotter_width = 20
+    plotter_height = 10
+    # Size and position of hole markers
+    FilmHoleHeightTop = int(PreviewHeight / 5.9)
+    FilmHoleHeightBottom = int(PreviewHeight / 3.7)
+    FilmHoleY_Top = 6
+    FilmHoleY_Bottom = int(PreviewHeight / 1.25)
     if ExpertMode or ExperimentalMode:
-        app_height += 325 if BigSize else 265
+        app_height += 325
+    # Check if window fits on screen, otherwise reduce and add croll bar
+    if app_height > screen_height:
+        app_height = screen_height - 128
+    # Save original ap height for toggle UI button
+    original_app_height = app_height
     # Prevent window resize
     win.minsize(app_width, app_height)
     win.maxsize(app_width, app_height)
@@ -2688,10 +2715,17 @@ def create_main_window():
     if 'WindowPos' in SessionData:
         win.geometry(f"+{SessionData['WindowPos'].split('+', 1)[1]}")
 
+    logging.info(f"Screen size: {screen_width}x{screen_height}")
+    logging.info(f"Window size: {app_width}x{app_height+20}")
+
+    # Catch closing with 'X' button
+    win.protocol("WM_DELETE_WINDOW", exit_app)
+
     # Init ToolTips
     as_tooltips = Tooltips(FontSize)
 
     create_widgets()
+
 
     # Get Top window coordinates
     TopWinX = win.winfo_x()
@@ -2846,7 +2880,7 @@ def value_validation(new_value, widget, min, max, default, is_double=False):
 
 def set_auto_exposure():
     aux = 0 if AE_enabled.get() else int(exposure_value.get() * 1000)
-
+    auto_exposure_btn.config(text="Auto Exp:" if AE_enabled.get() else "Exposure:")
     arrange_widget_state(AE_enabled.get(), [exposure_spinbox])
     arrange_widget_state(not AE_enabled.get(), [auto_exposure_wait_btn,
                                                 AeConstraintMode_label, AeConstraintMode_dropdown,
@@ -2950,7 +2984,8 @@ def set_AwbMode(selected):
 
 
 def steps_per_frame_auto():
-    arrange_widget_state(auto_framesteps_enabled.get(), [steps_per_frame_btn, steps_per_frame_spinbox])
+    arrange_widget_state(auto_framesteps_enabled.get(), [steps_per_frame_spinbox])
+    steps_per_frame_btn.config(text="Steps/Frame AUTO:" if auto_framesteps_enabled.get() else "Steps/Frame:")
     SessionData["FrameStepsAuto"] = auto_framesteps_enabled.get()
     send_arduino_command(CMD_SET_MIN_FRAME_STEPS, 0 if auto_framesteps_enabled.get() else steps_per_frame_value.get())
 
@@ -2969,7 +3004,8 @@ def steps_per_frame_validation(new_value):
 
 
 def set_auto_pt_level():
-    arrange_widget_state(auto_pt_level_enabled.get(), [pt_level_btn, pt_level_spinbox])
+    arrange_widget_state(auto_pt_level_enabled.get(), [pt_level_spinbox])
+    pt_level_btn.config(text="PT Level AUTO:" if auto_pt_level_enabled.get() else "PT Level:")
     SessionData["PTLevelAuto"] = auto_pt_level_enabled.get()
     send_arduino_command(CMD_SET_PT_LEVEL, 0 if auto_pt_level_enabled.get() else pt_level_value.get())
 
@@ -3176,17 +3212,14 @@ def sharpness_validation(new_value):
 
 def rwnd_speed_control_selection():
     value_normalize(rwnd_speed_control_value, 40, 800, 800)
-    '''
-    if event == 'Up':
-        print("Telling arduino to speed up")
-        rwnd_speed_up()
-    elif event == 'Down':
-        print("Telling arduino to slow down")
-        rwnd_speed_down()
-    '''
 
 def rewind_speed_validation(new_value):
     return value_validation(new_value, rwnd_speed_control_spinbox, 40, 800, 800)
+
+
+def update_target_dir_wraplength(event):
+    folder_frame_target_dir.config(wraplength=event.width - 20)  # Adjust the padding as needed
+
 
 
 # ***************
@@ -3214,7 +3247,8 @@ def create_widgets():
     global temp_in_fahrenheit
     global auto_white_balance_change_pause
     global auto_wb_wait_btn
-    global film_hole_frame_1, film_hole_frame_2, FilmHoleY1, FilmHoleY2
+    global film_hole_frame_top, film_hole_frame_bottom
+    global FilmHoleHeightTop, FilmHoleHeightBottom, FilmHoleY_Top, FilmHoleY_Bottom
     global temp_in_fahrenheit_checkbox
     global real_time_display_checkbox, real_time_display
     global real_time_zoom_checkbox, real_time_zoom
@@ -3238,13 +3272,13 @@ def create_widgets():
     global hdr_capture_active_checkbox, hdr_capture_active, hdr_viewx4_active
     global hdr_viewx4_active_checkbox, hdr_min_exp_label, hdr_min_exp_spinbox, hdr_max_exp_label, hdr_max_exp_spinbox, hdr_max_exp_value, hdr_min_exp_value
     global steps_per_frame_btn, auto_framesteps_enabled, pt_level_btn, auto_pt_level_enabled
-    global auto_exposure_btn, auto_wb_btn, exposure_spinbox, wb_red_spinbox, wb_blue_spinbox
+    global auto_exposure_btn, auto_wb_red_btn, auto_wb_blue_btn, exposure_spinbox, wb_red_spinbox, wb_blue_spinbox
     global hdr_bracket_width_spinbox, hdr_bracket_shift_spinbox, hdr_bracket_width_label, hdr_bracket_shift_label
     global hdr_bracket_width_value, hdr_bracket_shift_value
     global hdr_bracket_auto, hdr_bracket_width_auto_checkbox
     global hdr_merge_in_place, hdr_bracket_width_auto_checkbox, hdr_merge_in_place_checkbox
     global frames_to_go_str, FramesToGo, time_to_go_str
-    global RetreatMovie_btn
+    global RetreatMovie_btn, Manual_scan_checkbox
     global file_type_dropdown, file_type_dropdown_selected
     global resolution_dropdown, resolution_dropdown_selected
     global Scanned_Images_number_str, Scanned_Images_time_str, Scanned_Images_Fpm_str
@@ -3260,46 +3294,85 @@ def create_widgets():
     global AeConstraintMode_label, AeMeteringMode_label, AeExposureMode_label, AwbMode_label
     global brightness_value, contrast_value, saturation_value, analogue_gain_value, exposure_compensation_value, preview_module_value
     global brightness_spinbox, contrast_spinbox, saturation_spinbox, analogue_gain_spinbox, exposure_compensation_spinbox, preview_module_spinbox
+    global scrolled_canvas
+    global PreviewWidth, PreviewHeight
+    global plotter_width, plotter_height
+    global app_width, app_height
+
+    # Global value for separations between widgets
+    y_pad = 2
+    x_pad = 2
+
+    # Check if vertical scrollbar required
+    if add_vertical_scrollbar:
+        # Create a canvas widget
+        scrolled_canvas = tk.Canvas(win)
+
+        # Add a horizontal scrollbar to the canvas
+        scrolled_canvas_scrollbar_h = tk.Scrollbar(win, orient=tk.HORIZONTAL, command=scrolled_canvas.xview)
+        scrolled_canvas_scrollbar_h.pack(side=tk.BOTTOM, fill=tk.X)
+
+        scrolled_canvas.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+
+        # Add a vertical scrollbar to the canvas
+        scrolled_canvas_scrollbar_v = tk.Scrollbar(win, command=scrolled_canvas.yview)
+        scrolled_canvas_scrollbar_v.pack(side=tk.RIGHT, fill=tk.Y)
+
+        # Configure the canvas to use the scrollbar
+        scrolled_canvas.configure(xscrollcommand=scrolled_canvas_scrollbar_h.set, yscrollcommand=scrolled_canvas_scrollbar_v.set)
+
+        # Create a frame inside the canvas to hold the content
+        scrolled_frame = tk.Frame(scrolled_canvas)
+        scrolled_canvas.create_window((0, 0), window=scrolled_frame, anchor="nw")
+
+        # Bind the frame to the canvas so it resizes properly
+        scrolled_frame.bind("<Configure>", on_configure_scrolled_canvas)
+
+        main_container = scrolled_frame
+    else:
+        scrolled_canvas = None
+        main_container = win
 
     # Create a frame to contain the top area (preview + Right buttons) ***************
-    top_area_frame = Frame(win)
-    top_area_frame.pack(side=TOP, anchor=NW, fill='both')
+    top_area_frame = Frame(main_container)
+    top_area_frame.pack(side=TOP, pady=(8, 0), anchor=NW, fill='both')
+
     # Create a frame to contain the top right area (buttons) ***************
     top_left_area_frame = Frame(top_area_frame)
-    top_left_area_frame.pack(side=LEFT, anchor=NW, padx=(5, 0), pady=(20, 0), fill=Y)
-    # Create a LabelFrame to act as a border
+    top_left_area_frame.pack(side=LEFT, anchor=N, padx=(10, 0))
+    # Create a LabelFrame to act as a border of preview canvas
     draw_capture_frame = tk.LabelFrame(top_area_frame, bd=2, relief=tk.GROOVE)
-    draw_capture_frame.pack(side=LEFT, anchor=N, padx=(15, 0), pady=(20, 0), fill='y')
+    draw_capture_frame.pack(side=LEFT, anchor=N, padx=(10, 0), pady=(2,0))  # Pady+=2 to compensate
     # Create the canvas
-    draw_capture_canvas = Canvas(draw_capture_frame, bg='dark grey',
-                                 width=PreviewWidth, height=PreviewHeight)
+    draw_capture_canvas = Canvas(draw_capture_frame, bg='dark grey', width=PreviewWidth, height=PreviewHeight)
     draw_capture_canvas.pack(padx=(20,5), pady=5)
     # Create a frame to contain the top right area (buttons) ***************
     top_right_area_frame = Frame(top_area_frame)
-    top_right_area_frame.pack(side=LEFT, anchor=NW, padx=(5, 0), pady=(20, 0), fill=Y)
+    top_right_area_frame.pack(side=LEFT, anchor=N, padx=(10, 0))
 
     # ***************************************
     # Display markers for film hole reference
-    film_hole_frame_1 = Frame(draw_capture_frame, width=1, height=1, bg='black')
-    film_hole_frame_1.pack(side=TOP, padx=1, pady=1)
-    film_hole_frame_1.place(x=0, y=FilmHoleY1, height=140 if BigSize else 100)
-    film_hole_label_1 = Label(film_hole_frame_1, justify=LEFT, font=("Arial", FontSize), width=2, height=11,
+    # Size & postition of markers relative to preview height
+    film_hole_frame_top = Frame(draw_capture_frame, width=1, height=1, bg='black')
+    film_hole_frame_top.pack(side=TOP, padx=1, pady=1)
+    film_hole_frame_top.place(x=0, y=FilmHoleY_Top, height=FilmHoleHeightTop)
+    film_hole_label_1 = Label(film_hole_frame_top, justify=LEFT, font=("Arial", FontSize), width=2, height=11,
                               bg='white', fg='white')
     film_hole_label_1.pack(side=TOP)
 
-    film_hole_frame_2 = Frame(draw_capture_frame, width=1, height=1, bg='black')
-    film_hole_frame_2.pack(side=TOP, padx=1, pady=1)
-    film_hole_frame_2.place(x=0, y=FilmHoleY2, height=140 if BigSize else 100)
-    film_hole_label_2 = Label(film_hole_frame_2, justify=LEFT, font=("Arial", FontSize), width=2, height=11,
+    film_hole_frame_bottom = Frame(draw_capture_frame, width=1, height=1, bg='black')
+    film_hole_frame_bottom.pack(side=TOP, padx=1, pady=1)
+    film_hole_frame_bottom.place(x=0, y=FilmHoleY_Bottom, height=FilmHoleHeightBottom)
+    film_hole_label_2 = Label(film_hole_frame_bottom, justify=LEFT, font=("Arial", FontSize), width=2, height=11,
                               bg='white', fg='white')
     film_hole_label_2.pack(side=TOP)
 
     # Advance movie button (slow forward through filmgate)
     bottom_area_column = 0
     bottom_area_row = 0
-    AdvanceMovie_btn = Button(top_left_area_frame, text="Movie Forward", width=12, height=3, command=advance_movie,
-                              activebackground='#f0f0f0', wraplength=80, relief=RAISED, font=("Arial", FontSize))
-    AdvanceMovie_btn.grid(row=bottom_area_row, column=bottom_area_column, columnspan=2, padx=(5,0), pady=(0,4), sticky='NSEW')
+    AdvanceMovie_btn = Button(top_left_area_frame, text="Movie Forward", command=advance_movie,
+                              activebackground='#f0f0f0', relief=RAISED, font=("Arial", FontSize))
+    AdvanceMovie_btn.grid(row=bottom_area_row, column=bottom_area_column, columnspan=2, padx=x_pad, pady=y_pad, sticky='NSEW')
     as_tooltips.add(AdvanceMovie_btn, "Advance film (can be used with real-time view enabled).")
     bottom_area_row += 1
     # Once first button created, get default colors, to revert when we change them
@@ -3307,36 +3380,35 @@ def create_widgets():
     save_fg = AdvanceMovie_btn['fg']
 
     # Frame for single step/snapshot
-    sstep_area_frame = Frame(top_left_area_frame, width=50, height=50)
+    sstep_area_frame = Frame(top_left_area_frame)
     sstep_area_frame.grid_forget()
     # Advance one single frame
-    SingleStep_btn = Button(sstep_area_frame, text="Single Step", width=6, height=1, command=single_step_movie,
-                            activebackground='#f0f0f0', wraplength=80, font=("Arial", FontSize))
+    SingleStep_btn = Button(sstep_area_frame, text="Single Step", command=single_step_movie,
+                            activebackground='#f0f0f0', font=("Arial", FontSize))
     SingleStep_btn.grid_forget()
-    Snapshot_btn = Button(sstep_area_frame, text="Snapshot", width=6, height=1, command=capture_single_step,
-                            activebackground='#f0f0f0', wraplength=80, font=("Arial", FontSize))
+    Snapshot_btn = Button(sstep_area_frame, text="Snapshot", command=capture_single_step,
+                            activebackground='#f0f0f0', font=("Arial", FontSize))
     Snapshot_btn.grid_forget()
 
     # Rewind movie (via upper path, outside of film gate)
     Rewind_btn = Button(top_left_area_frame, text="<<", font=("Arial", FontSize+3), height=2, command=rewind_movie,
-                        activebackground='#f0f0f0', wraplength=80, relief=RAISED)
-    Rewind_btn.grid(row=bottom_area_row, column=bottom_area_column, padx=(5,0), pady=4, sticky='NSEW')
+                        activebackground='#f0f0f0', relief=RAISED)
+    Rewind_btn.grid(row=bottom_area_row, column=bottom_area_column, padx=x_pad, pady=y_pad, sticky='NSEW')
     as_tooltips.add(Rewind_btn, "Rewind film. Make sure film is routed via upper rolls.")
     # Fast Forward movie (via upper path, outside of film gate)
     FastForward_btn = Button(top_left_area_frame, text=">>", font=("Arial", FontSize+3), height=2, command=fast_forward_movie,
-                             activebackground='#f0f0f0', wraplength=80, relief=RAISED)
-    FastForward_btn.grid(row=bottom_area_row, column=bottom_area_column+1, padx=(5,0), pady=4, sticky='NSEW')
+                             activebackground='#f0f0f0', relief=RAISED)
+    FastForward_btn.grid(row=bottom_area_row, column=bottom_area_column+1, padx=x_pad, pady=y_pad, sticky='NSEW')
     as_tooltips.add(FastForward_btn, "Fast-forward film. Make sure film is routed via upper rolls.")
     bottom_area_row += 1
 
     # Switch Positive/negative modes
     negative_image = tk.BooleanVar(value=False)
-    #toggle_btn = tk.Checkbutton(root, text="Toggle", variable=var, command=toggle_button, indicatoron=False)
-    negative_image_checkbox = tk.Checkbutton(top_left_area_frame, text='Negative film', height=1,
+    negative_image_checkbox = tk.Checkbutton(top_left_area_frame, text='Negative film',
                                                  variable=negative_image, onvalue=True, offvalue=False,
                                                  font=("Arial", FontSize), command=set_negative_image,
-                                                 indicatoron=False, selectcolor="sea green")
-    negative_image_checkbox.grid(row=bottom_area_row, column=bottom_area_column, columnspan=2, padx=2, pady=1, ipadx=5, ipady=5, sticky='NSEW')
+                                                 indicatoron=False, selectcolor="pale green")
+    negative_image_checkbox.grid(row=bottom_area_row, column=bottom_area_column, columnspan=2, padx=x_pad, pady=y_pad, sticky='NSEW')
     as_tooltips.add(negative_image_checkbox, "Enable negative film capture (untested with real negative film)")
     bottom_area_row += 1
 
@@ -3345,8 +3417,8 @@ def create_widgets():
     real_time_display_checkbox = tk.Checkbutton(top_left_area_frame, text='Focus view', height=1,
                                                 variable=real_time_display, onvalue=True, offvalue=False,
                                                 font=("Arial", FontSize), command=set_real_time_display,
-                                                indicatoron=False, selectcolor="sea green")
-    real_time_display_checkbox.grid(row=bottom_area_row, column=bottom_area_column, columnspan=2, padx=2, pady=1, ipadx=5, ipady=5, sticky='NSEW')
+                                                indicatoron=False, selectcolor="pale green")
+    real_time_display_checkbox.grid(row=bottom_area_row, column=bottom_area_column, columnspan=2, padx=x_pad, pady=y_pad, sticky='NSEW')
     as_tooltips.add(real_time_display_checkbox, "Enable real-time film preview. Cannot be used while scanning, useful mainly to focus the film.")
     bottom_area_row += 1
 
@@ -3355,18 +3427,18 @@ def create_widgets():
     real_time_zoom_checkbox = tk.Checkbutton(top_left_area_frame, text='Zoom view', height=1,
                                              variable=real_time_zoom, onvalue=True, offvalue=False,
                                              font=("Arial", FontSize), command=set_focus_zoom, indicatoron=False,
-                                             selectcolor="sea green", state=DISABLED)
-    real_time_zoom_checkbox.grid(row=bottom_area_row, column=bottom_area_column, columnspan=2, padx=2, pady=1, ipadx=5, ipady=5, sticky='NSEW')
+                                             selectcolor="pale green", state=DISABLED)
+    real_time_zoom_checkbox.grid(row=bottom_area_row, column=bottom_area_column, columnspan=2, padx=x_pad, pady=y_pad, sticky='NSEW')
     as_tooltips.add(real_time_zoom_checkbox, "Zoom in on the real-time film preview. Useful to focus the film")
     bottom_area_row += 1
 
     # Focus zoom control (in out, up, down, left, right)
     Focus_frame = LabelFrame(top_left_area_frame, text='Zoom control', height=3, font=("Arial", FontSize-2))
-    Focus_frame.grid(row=bottom_area_row, column=bottom_area_column, columnspan=2, pady=4, ipady=2, sticky='NSEW')
+    Focus_frame.grid(row=bottom_area_row, column=bottom_area_column, columnspan=2, padx=x_pad, pady=y_pad, sticky='NSEW')
     bottom_area_row += 1
 
-    Focus_btn_grid_frame = Frame(Focus_frame, width=10, height=10)
-    Focus_btn_grid_frame.pack()
+    Focus_btn_grid_frame = Frame(Focus_frame)
+    Focus_btn_grid_frame.pack(padx=x_pad, pady=y_pad)
 
     # focus zoom displacement buttons, to further facilitate focusing the camera
     focus_plus_btn = Button(Focus_btn_grid_frame, text="+", height=1, command=set_focus_plus,
@@ -3397,14 +3469,13 @@ def create_widgets():
 
     # Frame for automatic stop & methods
     autostop_frame = Frame(top_left_area_frame)
-    autostop_frame.grid(row=bottom_area_row, column=bottom_area_column, columnspan=2, padx=2, pady=1, sticky='WE')
+    autostop_frame.grid(row=bottom_area_row, column=bottom_area_column, columnspan=2, padx=x_pad, pady=y_pad, sticky='WE')
 
     # Activate focus zoom, to facilitate focusing the camera
     auto_stop_enabled = tk.BooleanVar(value=False)
     auto_stop_enabled_checkbox = tk.Checkbutton(autostop_frame, text='Auto-stop if', height=1,
                                                  variable=auto_stop_enabled, onvalue=True, offvalue=False,
                                                  font=("Arial", FontSize), command=set_auto_stop_enabled)
-    #auto_stop_enabled_checkbox.grid(row=bottom_area_row, column=bottom_area_column, columnspan=2, padx=2, pady=1, sticky='W')
     auto_stop_enabled_checkbox.pack(side = TOP, anchor=W)
     as_tooltips.add(auto_stop_enabled_checkbox, "Stop scanning when end of film detected")
 
@@ -3413,11 +3484,11 @@ def create_widgets():
     autostop_type.set('No_film')
     autostop_no_film_rb = tk.Radiobutton(autostop_frame, text="No film", variable=autostop_type,
                                   value='No_film', font=("Arial", FontSize), command=set_auto_stop_enabled)
-    autostop_no_film_rb.pack(side=TOP, anchor=W, padx=10)
+    autostop_no_film_rb.pack(side=TOP, anchor=W, padx=(10,0))
     as_tooltips.add(autostop_no_film_rb, "Stop when film is not detected by PT")
     autostop_counter_zero_rb = tk.Radiobutton(autostop_frame, text="Count zero", variable=autostop_type,
                                   value='counter_to_zero', font=("Arial", FontSize), command=set_auto_stop_enabled)
-    autostop_counter_zero_rb.pack(side=TOP, anchor=W, padx=10)
+    autostop_counter_zero_rb.pack(side=TOP, anchor=W, padx=(10,0))
     as_tooltips.add(autostop_counter_zero_rb, "Stop scan when frames-to-go counter reaches zero")
     autostop_no_film_rb.config(state = DISABLED)
     autostop_counter_zero_rb.config(state = DISABLED)
@@ -3432,99 +3503,98 @@ def create_widgets():
                                                  font=("Arial", FontSize), command=toggle_ui_size, indicatoron=False,
                                                  selectcolor="sea green")
 
-        full_ui_checkbox.grid(row=bottom_area_row, column=bottom_area_column, columnspan=2, padx=2, pady=1, ipadx=5, ipady=5, sticky='NSEW')
+        full_ui_checkbox.grid(row=bottom_area_row, column=bottom_area_column, columnspan=2, padx=x_pad, pady=y_pad, sticky='NSEW')
         as_tooltips.add(full_ui_checkbox, "Toggle between full/restricted user interface")
         bottom_area_row += 1
 
         # Statictics sub-frame
         statistics_frame = LabelFrame(top_left_area_frame, text='Avrg time (ms)', font=("Arial", FontSize-1))
-        statistics_frame.grid(row=bottom_area_row, column=bottom_area_column, columnspan=2, padx=2, pady=1, ipadx=5, ipady=5, sticky='NSEW')
+        statistics_frame.grid(row=bottom_area_row, column=bottom_area_column, columnspan=2, padx=x_pad, pady=y_pad, sticky='NSEW')
         # Average Time to save image
         time_save_image_label = tk.Label(statistics_frame, text='Save:', font=("Arial", FontSize-1))
-        time_save_image_label.grid(row=0, column=0, padx=6, sticky=E)
+        time_save_image_label.grid(row=0, column=0, sticky=E)
         as_tooltips.add(time_save_image_label, "Average time spent in saving each frame (in milliseconds)")
         time_save_image_value = tk.IntVar(value=0)
         time_save_image_value_label = tk.Label(statistics_frame, textvariable=time_save_image_value, font=("Arial", FontSize-1))
-        time_save_image_value_label.grid(row=0, column=1, padx=2, sticky=W)
+        time_save_image_value_label.grid(row=0, column=1, sticky=W)
         as_tooltips.add(time_save_image_value_label, "Average time spent in saving each frame (in milliseconds)")
         time_save_image_label_ms = tk.Label(statistics_frame, text='ms', font=("Arial", FontSize-1))
-        time_save_image_label_ms.grid(row=0, column=2, padx=6, sticky=E)
+        time_save_image_label_ms.grid(row=0, column=2, sticky=E)
         # Average Time to display preview
         time_preview_display_label = tk.Label(statistics_frame, text='Prvw:', font=("Arial", FontSize-1))
-        time_preview_display_label.grid(row=1, column=0, padx=6, sticky=E)
+        time_preview_display_label.grid(row=1, column=0, sticky=E)
         as_tooltips.add(time_preview_display_label, "Average time spent in displaying a preview of each frame (in milliseconds)")
         time_preview_display_value = tk.IntVar(value=0)
         time_preview_display_value_label = tk.Label(statistics_frame, textvariable=time_preview_display_value, font=("Arial", FontSize-1))
-        time_preview_display_value_label.grid(row=1, column=1, padx=2, sticky=W)
+        time_preview_display_value_label.grid(row=1, column=1, sticky=W)
         as_tooltips.add(time_preview_display_value_label, "Average time spent in displaying a preview of each frame (in milliseconds)")
         time_preview_display_label_ms = tk.Label(statistics_frame, text='ms', font=("Arial", FontSize-1))
-        time_preview_display_label_ms.grid(row=1, column=2, padx=6, sticky=E)
+        time_preview_display_label_ms.grid(row=1, column=2, sticky=E)
         # Average Time spent waiting for AWB to adjust
         time_awb_label = tk.Label(statistics_frame, text='AWB:', font=("Arial", FontSize-1))
-        time_awb_label.grid(row=2, column=0, padx=6, sticky=E)
+        time_awb_label.grid(row=2, column=0, sticky=E)
         as_tooltips.add(time_awb_label, "Average time spent waiting for white balance to match automatic value (in milliseconds)")
         time_awb_value = tk.IntVar(value=0)
         time_awb_value_label = tk.Label(statistics_frame, textvariable=time_awb_value, font=("Arial", FontSize-1))
-        time_awb_value_label.grid(row=2, column=1, padx=2, sticky=W)
+        time_awb_value_label.grid(row=2, column=1, sticky=W)
         as_tooltips.add(time_awb_value_label, "Average time spent waiting for white balance to match automatic value (in milliseconds)")
         time_awb_label_ms = tk.Label(statistics_frame, text='ms', font=("Arial", FontSize-1))
-        time_awb_label_ms.grid(row=2, column=2, padx=6, sticky=E)
+        time_awb_label_ms.grid(row=2, column=2, sticky=E)
         # Average Time spent waiting for AE to adjust
         time_autoexp_label = tk.Label(statistics_frame, text='AE:', font=("Arial", FontSize-1))
-        time_autoexp_label.grid(row=3, column=0, padx=6, sticky=E)
+        time_autoexp_label.grid(row=3, column=0, sticky=E)
         as_tooltips.add(time_autoexp_label, "Average time spent waiting for exposure to match automatic value (in milliseconds)")
         time_autoexp_value = tk.IntVar(value=0)
         time_autoexp_value_label = tk.Label(statistics_frame, textvariable=time_autoexp_value, font=("Arial", FontSize-1))
-        time_autoexp_value_label.grid(row=3, column=1, padx=2, sticky=W)
+        time_autoexp_value_label.grid(row=3, column=1, sticky=W)
         as_tooltips.add(time_autoexp_value_label, "Average time spent waiting for exposure to match automatic value (in milliseconds)")
         time_autoexp_label_ms = tk.Label(statistics_frame, text='ms', font=("Arial", FontSize-1))
-        time_autoexp_label_ms.grid(row=3, column=2, padx=6, sticky=E)
+        time_autoexp_label_ms.grid(row=3, column=2, sticky=E)
         bottom_area_row += 1
-
-
 
     # Create vertical button column at right *************************************
     # Application Exit button
     top_right_area_row = 0
-    Exit_btn = Button(top_right_area_frame, text="Exit", height=5, command=exit_app, activebackground='red',
+    Exit_btn = Button(top_right_area_frame, text="Exit", height=4, command=exit_app, activebackground='red',
                       activeforeground='white', font=("Arial", FontSize))
-    Exit_btn.grid(row=top_right_area_row, column=0, padx=4, pady=(0,3), sticky='EW')
+    Exit_btn.grid(row=top_right_area_row, column=0, padx=x_pad, pady=y_pad, sticky='EW')
     as_tooltips.add(Exit_btn, "Exit ALT-Scann8.")
 
     # Start scan button
     if SimulatedRun:
-        Start_btn = Button(top_right_area_frame, text="START Scan", height=5, command=start_scan_simulated,
+        Start_btn = Button(top_right_area_frame, text="START Scan", height=4, command=start_scan_simulated,
                            activebackground='#f0f0f0', font=("Arial", FontSize))
     else:
-        Start_btn = Button(top_right_area_frame, text="START Scan", height=5, command=start_scan,
+        Start_btn = Button(top_right_area_frame, text="START Scan", height=4, command=start_scan,
                            activebackground='#f0f0f0', font=("Arial", FontSize))
-    Start_btn.grid(row=top_right_area_row, column=1, pady=(0,3), sticky='EW')
+    Start_btn.grid(row=top_right_area_row, column=1, padx=x_pad, pady=y_pad, sticky='EW')
     as_tooltips.add(Start_btn, "Start scanning process.")
     top_right_area_row += 1
 
     # Create frame to select target folder
     folder_frame = LabelFrame(top_right_area_frame, text='Target Folder', height=8, font=("Arial", FontSize-2))
-    folder_frame.grid(row=top_right_area_row, column=0, columnspan=2, padx=4, pady=4, sticky='EW')
+    folder_frame.grid(row=top_right_area_row, column=0, columnspan=2, padx=x_pad, pady=y_pad, sticky='EW')
+    # Bind the frame's resize event to the function that updates the wraplength
+    folder_frame.bind("<Configure>", update_target_dir_wraplength)
 
-    folder_frame_target_dir = Label(folder_frame, text=CurrentDir, width=50 if BigSize else 55, height=3, font=("Arial", FontSize-3),
-                                    wraplength=200)
+    folder_frame_target_dir = Label(folder_frame, text=CurrentDir, wraplength=150, height=3, font=("Arial", FontSize-3))
     folder_frame_target_dir.pack(side=TOP)
 
-    folder_frame_buttons = Frame(folder_frame, width=16, height=4, bd=2)
+    folder_frame_buttons = Frame(folder_frame, bd=2)
     folder_frame_buttons.pack()
-    new_folder_btn = Button(folder_frame_buttons, text='New', width=10, height=1, command=set_new_folder,
-                            activebackground='#f0f0f0', wraplength=80, font=("Arial", FontSize-2))
+    new_folder_btn = Button(folder_frame_buttons, text='New', command=set_new_folder,
+                            activebackground='#f0f0f0', font=("Arial", FontSize-2))
     new_folder_btn.pack(side=LEFT)
     as_tooltips.add(new_folder_btn, "Create new folder to store frames generated during the scan.")
-    existing_folder_btn = Button(folder_frame_buttons, text='Existing', width=10, height=1, command=set_existing_folder,
-                                 activebackground='#f0f0f0', wraplength=80, font=("Arial", FontSize-2))
+    existing_folder_btn = Button(folder_frame_buttons, text='Existing', command=set_existing_folder,
+                                 activebackground='#f0f0f0', font=("Arial", FontSize-2))
     existing_folder_btn.pack(side=LEFT)
     as_tooltips.add(existing_folder_btn, "Select existing folder to store frames generated during the scan.")
     top_right_area_row += 1
 
     # Create frame to select target file specs
-    file_type_frame = LabelFrame(top_right_area_frame, text='Capture resolution & file type', height=8, font=("Arial", FontSize-2))
-    file_type_frame.grid(row=top_right_area_row, column=0, columnspan=2, padx=4, pady=4, sticky='EW')
+    file_type_frame = LabelFrame(top_right_area_frame, text='Capture resolution & file type', font=("Arial", FontSize-2))
+    file_type_frame.grid(row=top_right_area_row, column=0, columnspan=2, padx=x_pad, pady=y_pad, sticky='EW')
 
     # Capture resolution Dropdown
     # Drop down to select capture resolution
@@ -3533,8 +3603,9 @@ def create_widgets():
     resolution_dropdown_selected = tk.StringVar()
     resolution_dropdown_selected.set(resolution_list[1])  # Set the initial value
     resolution_label = Label(file_type_frame, text='Resolution:', font=("Arial", FontSize))
-    resolution_label.pack(side=LEFT)
-    #resolution_label.config(state=DISABLED)
+    #resolution_label.pack(side=LEFT)
+    resolution_label.pack_forget()
+    resolution_label.config(state=DISABLED)
     resolution_dropdown = OptionMenu(file_type_frame,
                                     resolution_dropdown_selected, *resolution_list, command=set_resolution)
     resolution_dropdown.config(takefocus=1, font=("Arial", FontSize))
@@ -3551,8 +3622,9 @@ def create_widgets():
 
     # No label for now
     file_type_label = Label(file_type_frame, text='Type:', font=("Arial", FontSize))
-    file_type_label.pack(side=LEFT)
-    # file_type_label.config(state=DISABLED)
+    #file_type_label.pack(side=LEFT)
+    file_type_label.pack_forget()
+    file_type_label.config(state=DISABLED)
     file_type_dropdown = OptionMenu(file_type_frame,
                                     file_type_dropdown_selected, *file_type_list, command=set_file_type)
     file_type_dropdown.config(takefocus=1, font=("Arial", FontSize))
@@ -3564,70 +3636,63 @@ def create_widgets():
 
     # Create frame to display number of scanned images, and frames per minute
     scanned_images_frame = LabelFrame(top_right_area_frame, text='Scanned frames', height=4, font=("Arial", FontSize-2))
-    scanned_images_frame.grid(row=top_right_area_row, column=0, padx=4, pady=4, sticky='NSEW')
+    scanned_images_frame.grid(row=top_right_area_row, column=0, padx=x_pad, pady=y_pad, sticky='NSEW')
 
     Scanned_Images_number_str = tk.StringVar(value=str(CurrentFrame))
-    Scanned_Images_number_label = Label(scanned_images_frame, textvariable=Scanned_Images_number_str, font=("Arial", FontSize+6), width=5,
-                                        height=1)
+    Scanned_Images_number_label = Label(scanned_images_frame, textvariable=Scanned_Images_number_str, font=("Arial", FontSize+6))
     Scanned_Images_number_label.pack(side=TOP)
     as_tooltips.add(Scanned_Images_number_label, "Number of film frames scanned so far.")
 
-    scanned_images_fpm_frame = Frame(scanned_images_frame, width=14, height=2)
+    scanned_images_fpm_frame = Frame(scanned_images_frame)
     scanned_images_fpm_frame.pack(side=TOP)
     Scanned_Images_time_str = tk.StringVar(value="Film time:")
-    Scanned_Images_time_label = Label(scanned_images_fpm_frame, textvariable=Scanned_Images_time_str, font=("Arial", FontSize-2), width=20,
-                               height=1)
+    Scanned_Images_time_label = Label(scanned_images_fpm_frame, textvariable=Scanned_Images_time_str, font=("Arial", FontSize-4))
     Scanned_Images_time_label.pack(side=BOTTOM)
     as_tooltips.add(Scanned_Images_time_label, "Film time in min:sec")
 
     Scanned_Images_Fpm_str = tk.StringVar(value="Frames/Min:")
-    scanned_images_fpm_label = Label(scanned_images_fpm_frame, textvariable=Scanned_Images_Fpm_str, font=("Arial", FontSize-2), width=20,
-                                     height=1)
+    scanned_images_fpm_label = Label(scanned_images_fpm_frame, textvariable=Scanned_Images_Fpm_str, font=("Arial", FontSize-4))
     scanned_images_fpm_label.pack(side=LEFT)
     as_tooltips.add(scanned_images_fpm_label, "Scan speed in frames per minute.")
 
     # Create frame to display number of frames to go, and estimated time to finish
-    frames_to_go_frame = LabelFrame(top_right_area_frame, text='Frames to go', height=4, font=("Arial", FontSize-2))
-    frames_to_go_frame.grid(row=top_right_area_row, column=1, padx=4, pady=4, sticky='NSEW')
+    frames_to_go_frame = LabelFrame(top_right_area_frame, text='Frames to go', font=("Arial", FontSize-2))
+    frames_to_go_frame.grid(row=top_right_area_row, column=1, padx=x_pad, pady=y_pad, sticky='NSEW')
     top_right_area_row += 1
 
     frames_to_go_str = tk.StringVar(value='')
-    frames_to_go_entry = tk.Entry(frames_to_go_frame, textvariable=frames_to_go_str, width=14, font=("Arial", FontSize-2), justify="right")
+    frames_to_go_entry = tk.Entry(frames_to_go_frame, textvariable=frames_to_go_str, width=5, font=("Arial", FontSize), justify="right")
     # Bind the KeyRelease event to the entry widget
     frames_to_go_entry.bind("<KeyPress>", frames_to_go_key_press)
-    frames_to_go_entry.pack(side=TOP, pady=6)
+    frames_to_go_entry.pack(side=TOP)
     as_tooltips.add(frames_to_go_entry, "Enter estimated number of frames to scan in order to get an estimation of remaining time to finish.")
     time_to_go_str = tk.StringVar(value='')
-    time_to_go_time = Label(frames_to_go_frame, textvariable=time_to_go_str, font=("Arial", FontSize-2), width=18 if BigSize else 24, height=1)
-    time_to_go_time.pack(side=TOP, pady=6)
+    time_to_go_time = Label(frames_to_go_frame, textvariable=time_to_go_str, font=("Arial", FontSize-4))
+    time_to_go_time.pack(side=TOP)
 
     # Create frame to select S8/R8 film
     film_type_frame = LabelFrame(top_right_area_frame, text='Film type', height=1, font=("Arial", FontSize-2))
-    film_type_frame.grid(row=top_right_area_row, column=0, padx=4, pady=4, sticky='NSEW')
+    film_type_frame.grid(row=top_right_area_row, column=0, padx=x_pad, pady=y_pad, sticky='NSEW')
 
     # Radio buttons to select R8/S8. Required to select adequate pattern, and match position
     film_type = tk.StringVar()
     film_type_S8_rb = tk.Radiobutton(film_type_frame, text="S8", variable=film_type, command=set_s8,
-                                  value='S8', font=("Arial", FontSize),
-                                  indicatoron=0, width=8, height=2,
-                                  compound='left', padx=0, pady=0,
-                                  relief="raised", borderwidth=3)
-    film_type_S8_rb.pack(side=LEFT, padx=2)
+                                  value='S8', font=("Arial", FontSize), indicatoron=0, width=5, height=2,
+                                  compound='left', relief="raised", borderwidth=3)
+    film_type_S8_rb.pack(side=LEFT)
     as_tooltips.add(film_type_S8_rb, "Handle as Super 8 film")
     film_type_R8_rb = tk.Radiobutton(film_type_frame, text="R8", variable=film_type, command=set_r8,
-                                  value='R8', font=("Arial", FontSize),
-                                  indicatoron=0, width=8, height=2,
-                                  compound='left', padx=0, pady=0,
-                                  relief="raised", borderwidth=3)
-    film_type_R8_rb.pack(side=RIGHT, padx=2)
+                                  value='R8', font=("Arial", FontSize), indicatoron=0, width=5, height=2,
+                                  compound='left', relief="raised", borderwidth=3)
+    film_type_R8_rb.pack(side=RIGHT)
     as_tooltips.add(film_type_R8_rb, "Handle as 8mm (Regular 8) film")
 
     # Create frame to display RPi temperature
     rpi_temp_frame = LabelFrame(top_right_area_frame, text='RPi Temp.', height=1, font=("Arial", FontSize-2))
-    rpi_temp_frame.grid(row=top_right_area_row, column=1, padx=4, pady=4, sticky='NSEW')
+    rpi_temp_frame.grid(row=top_right_area_row, column=1, padx=x_pad, pady=y_pad, sticky='NSEW')
     temp_str = str(RPiTemp)+'º'
-    RPi_temp_value_label = Label(rpi_temp_frame, text=temp_str, font=("Arial", FontSize+4), width=10, height=1)
-    RPi_temp_value_label.pack(side=TOP, padx=4)
+    RPi_temp_value_label = Label(rpi_temp_frame, text=temp_str, font=("Arial", FontSize+4))
+    RPi_temp_value_label.pack(side=TOP)
     as_tooltips.add(RPi_temp_value_label, "Raspberry Pi Temperature.")
 
     temp_in_fahrenheit = tk.BooleanVar(value=False)
@@ -3641,111 +3706,106 @@ def create_widgets():
     # Integrated plotter
     if PlotterMode:
         integrated_plotter_frame = LabelFrame(top_right_area_frame, text='Plotter Area', font=("Arial", FontSize - 1))
-        integrated_plotter_frame.grid(row=top_right_area_row, column=0, columnspan=2, padx=4, sticky='NS')
+        integrated_plotter_frame.grid(row=top_right_area_row, column=0, columnspan=2, padx=x_pad, pady=y_pad,
+                                      ipadx=2, ipady=2, sticky='NSEW')
         plotter_canvas = Canvas(integrated_plotter_frame, bg='white', width=plotter_width, height=plotter_height)
-        plotter_canvas.pack(side=TOP, anchor=N, padx=5, pady=5)
+        plotter_canvas.pack(side=TOP, anchor=N)
     top_right_area_row += 1
 
     # Create extended frame for expert and experimental areas
     if ExpertMode or ExperimentalMode:
-        extended_frame = Frame(win)
-        extended_frame.pack(side=TOP, anchor=W, padx=5, expand=True, fill="y")
+        extended_frame = Frame(main_container)
+        extended_frame.pack(side=LEFT, padx=10, expand=True, fill="y", anchor="center")
     if ExpertMode:
         expert_frame = LabelFrame(extended_frame, text='Expert Area', width=8, font=("Arial", FontSize-1))
-        expert_frame.pack(side=LEFT, padx=5, pady=5, ipadx=5, ipady=5, expand=True, fill='y')
+        expert_frame.pack(side=LEFT, padx=x_pad, pady=y_pad, expand=True, fill='y')
         #expert_frame.place(relx=0.25, rely=0.5, anchor="center")
         # *********************************
         # Exposure / white balance
         exp_wb_frame = LabelFrame(expert_frame, text='Auto Exposure / White Balance ', font=("Arial", FontSize-1))
-        exp_wb_frame.grid(row=0, rowspan=2, column=0, padx=5, ipady=5, sticky='NSEW')
+        exp_wb_frame.grid(row=0, rowspan=2, column=0, padx=x_pad, pady=y_pad, sticky='NSEW')
         exp_wb_row = 0
 
-        exp_wb_auto_label = tk.Label(exp_wb_frame, text='Auto', font=("Arial", FontSize-1))
-        exp_wb_auto_label.grid(row=exp_wb_row, column=3, pady=1)
-
         catch_up_delay_label = tk.Label(exp_wb_frame, text='Match\nwait', font=("Arial", FontSize-1))
-        catch_up_delay_label.grid(row=exp_wb_row, column=4, pady=1)
+        catch_up_delay_label.grid(row=exp_wb_row, column=2, sticky=W)
         exp_wb_row += 1
 
         # Automatic exposure
-        exposure_label = tk.Label(exp_wb_frame, text='Exposure:', font=("Arial", FontSize-1))
-        exposure_label.grid(row=exp_wb_row, column=0, pady=1, sticky=E)
+        AE_enabled = tk.BooleanVar(value=False)
+        auto_exposure_btn = tk.Checkbutton(exp_wb_frame, variable=AE_enabled, onvalue=True, offvalue=False,
+                                           font=("Arial", FontSize-1), command=set_auto_exposure, selectcolor="pale green",
+                                           text="Exposure:", relief="raised", indicatoron=False)
+        auto_exposure_btn.grid(row=exp_wb_row, column=0, sticky="EW")
+        as_tooltips.add(auto_exposure_btn, "Toggle automatic exposure status (on/off).")
 
         exposure_value = tk.DoubleVar(value=0)  # Auto exposure by default, overriden by configuration if any
         exposure_spinbox = DynamicSpinbox(exp_wb_frame, command=exposure_selection, width=8, textvariable=exposure_value,
-                                      from_=0.001, to=10000, increment=1, font=("Arial", FontSize-1), readonlybackground='pale green')
-        exposure_spinbox.grid(row=exp_wb_row, column=1, padx=5, pady=1, sticky=W)
+                                      from_=0.001, to=10000, increment=1, font=("Arial", FontSize-1))
+        exposure_spinbox.grid(row=exp_wb_row, column=1, padx=x_pad, pady=y_pad, sticky=W)
         exposure_validation_cmd = exposure_spinbox.register(exposure_validation)
         exposure_spinbox.configure(validate="key", validatecommand=(exposure_validation_cmd, '%P'))
         as_tooltips.add(exposure_spinbox, "When automatic exposure disabled, exposure time for the sensor to use, measured in milliseconds.")
         exposure_spinbox.bind("<FocusOut>", lambda event: exposure_selection())
 
-        AE_enabled = tk.BooleanVar(value=False)
-        auto_exposure_btn = tk.Checkbutton(exp_wb_frame, variable=AE_enabled, onvalue=True, offvalue=False,
-                                      font=("Arial", FontSize-1), command=set_auto_exposure)
-        auto_exposure_btn.grid(row=exp_wb_row, column=3, pady=1)
-        as_tooltips.add(auto_exposure_btn, "Toggle automatic exposure status (on/off).")
-
         auto_exposure_change_pause = tk.BooleanVar(value=True)  # Default value, to be overriden by configuration
         auto_exposure_wait_btn = tk.Checkbutton(exp_wb_frame, state=DISABLED, variable=auto_exposure_change_pause,
                                                 onvalue=True, offvalue=False, font=("Arial", FontSize-1),
                                                 command=auto_exposure_change_pause_selection)
-        auto_exposure_wait_btn.grid(row=exp_wb_row, column=4, pady=1)
+        auto_exposure_wait_btn.grid(row=exp_wb_row, column=2, sticky=W)
         as_tooltips.add(auto_exposure_wait_btn, "When automatic exposure enabled, select to wait for it to stabilize before capturing frame.")
         exp_wb_row += 1
 
         # Automatic White Balance red
-        wb_red_label = tk.Label(exp_wb_frame, text='WB Red:', font=("Arial", FontSize-1))
-        wb_red_label.grid(row=exp_wb_row, column=0, pady=1, sticky=E)
+        AWB_enabled = tk.BooleanVar(value=False)
+        auto_wb_red_btn = tk.Checkbutton(exp_wb_frame, variable=AWB_enabled, onvalue=True, offvalue=False,
+                                    font=("Arial", FontSize-1), command=set_auto_wb, selectcolor="pale green",
+                                    text="WB Red:", relief="raised", indicatoron=False)
+        auto_wb_red_btn.grid(row=exp_wb_row, column=0, sticky="WE")
+        as_tooltips.add(auto_wb_red_btn, "Toggle automatic white balance for both WB channels (on/off).")
 
         wb_red_value = tk.DoubleVar(value=2.2)  # Default value, overriden by configuration
-        wb_red_spinbox = DynamicSpinbox(exp_wb_frame, command=wb_red_selection, width=8, readonlybackground='pale green',
+        wb_red_spinbox = DynamicSpinbox(exp_wb_frame, command=wb_red_selection, width=8,
             textvariable=wb_red_value, from_=0, to=32, increment=0.1, font=("Arial", FontSize-1))
-        wb_red_spinbox.grid(row=exp_wb_row, column=1, padx=5, pady=1, sticky=W)
+        wb_red_spinbox.grid(row=exp_wb_row, column=1, padx=x_pad, pady=y_pad, sticky=W)
         wb_red_validation_cmd = wb_red_spinbox.register(wb_red_validation)
         wb_red_spinbox.configure(validate="key", validatecommand=(wb_red_validation_cmd, '%P'))
         as_tooltips.add(wb_red_spinbox, "When automatic white balance disabled, sets the red gain (the gain applied to red pixels by the AWB algorithm), between 0.0 to 32.0.")
         wb_red_spinbox.bind("<FocusOut>", lambda event: wb_red_selection())
 
-        wb_join_label = tk.Label(exp_wb_frame, text='}', width=1, font=("Arial", FontSize*2))   # ⎬ } ﹜
-        wb_join_label.grid(row=exp_wb_row, rowspan=2, column=2, padx=0, pady=1, sticky=W)
-
-        AWB_enabled = tk.BooleanVar(value=False)
-        auto_wb_btn = tk.Checkbutton(exp_wb_frame, variable=AWB_enabled, onvalue=True, offvalue=False,
-                                    font=("Arial", FontSize-1), command=set_auto_wb)
-        auto_wb_btn.grid(row=exp_wb_row, rowspan=2, column=3, pady=1)
-        as_tooltips.add(auto_wb_btn, "Toggle automatic white balance for red channel (on/off).")
-
         auto_white_balance_change_pause = tk.BooleanVar(value=False)
         auto_wb_wait_btn = tk.Checkbutton(exp_wb_frame, state=DISABLED, variable=auto_white_balance_change_pause,
                                                onvalue=True, offvalue=False, font=("Arial", FontSize-1),
                                                 command=auto_white_balance_change_pause_selection)
-        auto_wb_wait_btn.grid(row=exp_wb_row, rowspan=2, column=4, pady=1)
+        auto_wb_wait_btn.grid(row=exp_wb_row, rowspan=2, column=2, sticky=W)
         as_tooltips.add(auto_wb_wait_btn, "When automatic white balance enabled, select to wait for it to stabilize before capturing frame.")
         exp_wb_row += 1
 
         # Automatic White Balance blue
-        wb_blue_label = tk.Label(exp_wb_frame, text='WB Blue:', font=("Arial", FontSize-1))
-        wb_blue_label.grid(row=exp_wb_row, column=0, pady=1, sticky=E)
+        auto_wb_blue_btn = tk.Checkbutton(exp_wb_frame, variable=AWB_enabled, onvalue=True, offvalue=False,
+                                    font=("Arial", FontSize-1), command=set_auto_wb, selectcolor="pale green",
+                                    text="WB Blue:", relief="raised", indicatoron=False)
+        auto_wb_blue_btn.grid(row=exp_wb_row, column=0, sticky="WE")
+        as_tooltips.add(auto_wb_blue_btn, "Toggle automatic white balance for both WB channels (on/off).")
 
         wb_blue_value = tk.DoubleVar(value=2.2)  # Default value, overriden by configuration
-        wb_blue_spinbox = DynamicSpinbox(exp_wb_frame, command=wb_blue_selection, width=8, readonlybackground='pale green',
+        wb_blue_spinbox = DynamicSpinbox(exp_wb_frame, command=wb_blue_selection, width=8,
             textvariable=wb_blue_value, from_=0, to=32, increment=0.1, font=("Arial", FontSize-1))
-        wb_blue_spinbox.grid(row=exp_wb_row, column=1, padx=5, pady=1, sticky=W)
+        wb_blue_spinbox.grid(row=exp_wb_row, column=1, padx=x_pad, pady=y_pad, sticky=W)
         wb_blue_validation_cmd = wb_blue_spinbox.register(wb_blue_validation)
         wb_blue_spinbox.configure(validate="key", validatecommand=(wb_blue_validation_cmd, '%P'))
         as_tooltips.add(wb_blue_spinbox, "When automatic white balance disabled, sets the blue gain (the gain applied to blue pixels by the AWB algorithm), between 0.0 to 32.0.")
         wb_blue_spinbox.bind("<FocusOut>", lambda event: wb_blue_selection())
+
         exp_wb_row+= 1
 
         # Match wait (exposure & AWB) margin allowance (0%, wait for same value, 100%, any value will do)
         match_wait_margin_label = tk.Label(exp_wb_frame, text='Match margin (%):', font=("Arial", FontSize-1))
-        match_wait_margin_label.grid(row=exp_wb_row, column=0, pady=1, sticky=E)
+        match_wait_margin_label.grid(row=exp_wb_row, column=0, padx=x_pad, pady=y_pad, sticky=E)
 
         match_wait_margin_value = tk.IntVar(value=50)  # Default value, overriden by configuration
         match_wait_margin_spinbox = DynamicSpinbox(exp_wb_frame, command=match_wait_margin_selection, width=8, readonlybackground='pale green',
             textvariable=match_wait_margin_value, from_=5, to=100, increment=5, font=("Arial", FontSize-1))
-        match_wait_margin_spinbox.grid(row=exp_wb_row, column=1, padx=5, pady=1, sticky=W)
+        match_wait_margin_spinbox.grid(row=exp_wb_row, column=1, padx=x_pad, pady=y_pad, sticky=W)
         match_wait_margin_validation_cmd = match_wait_margin_spinbox.register(match_wait_margin_validation)
         match_wait_margin_spinbox.configure(validate="key", validatecommand=(match_wait_margin_validation_cmd, '%P'))
         as_tooltips.add(match_wait_margin_spinbox, "When automatic exposure/WB enabled, and match wait delay is selected, the tolerance for the match (5%, lowest tolerance, almost exact match required, 100% any value will match)")
@@ -3756,11 +3816,11 @@ def create_widgets():
         AeConstraintMode_dropdown_selected = tk.StringVar()
         AeConstraintMode_dropdown_selected.set("Normal")  # Set the initial value
         AeConstraintMode_label = Label(exp_wb_frame, text='AE Const. mode:', font=("Arial", FontSize-1), state=DISABLED)
-        AeConstraintMode_label.grid(row=exp_wb_row, column=0, pady=1, sticky=E)
+        AeConstraintMode_label.grid(row=exp_wb_row, column=0, padx=x_pad, pady=y_pad, sticky=E)
         AeConstraintMode_dropdown = OptionMenu(exp_wb_frame, AeConstraintMode_dropdown_selected,
                                                *AeConstraintMode_dict.keys(), command=set_AeConstraintMode)
         AeConstraintMode_dropdown.config(takefocus=1, font=("Arial", FontSize-1), state=DISABLED)
-        AeConstraintMode_dropdown.grid(row=exp_wb_row, columnspan=4, column=1, pady=1, sticky=W)
+        AeConstraintMode_dropdown.grid(row=exp_wb_row, columnspan=2, column=1, padx=x_pad, pady=y_pad, sticky=W)
         as_tooltips.add(AeConstraintMode_dropdown, "Sets the constraint mode of the AEC/AGC algorithm.")
         exp_wb_row+= 1
 
@@ -3769,11 +3829,11 @@ def create_widgets():
         AeMeteringMode_dropdown_selected = tk.StringVar()
         AeMeteringMode_dropdown_selected.set("CentreWeighted")  # Set the initial value
         AeMeteringMode_label = Label(exp_wb_frame, text='AE Meter mode:', font=("Arial", FontSize-1), state=DISABLED)
-        AeMeteringMode_label.grid(row=exp_wb_row, column=0, pady=1, sticky=E)
+        AeMeteringMode_label.grid(row=exp_wb_row, column=0, padx=x_pad, pady=y_pad, sticky=E)
         AeMeteringMode_dropdown = OptionMenu(exp_wb_frame, AeMeteringMode_dropdown_selected,
                                              *AeMeteringMode_dict.keys(), command=set_AeMeteringMode)
         AeMeteringMode_dropdown.config(takefocus=1, font=("Arial", FontSize-1), state=DISABLED)
-        AeMeteringMode_dropdown.grid(row=exp_wb_row, columnspan=4, column=1, pady=1, sticky=W)
+        AeMeteringMode_dropdown.grid(row=exp_wb_row, columnspan=2, column=1, padx=x_pad, pady=y_pad, sticky=W)
         as_tooltips.add(AeMeteringMode_dropdown, "Sets the metering mode of the AEC/AGC algorithm.")
         exp_wb_row+= 1
 
@@ -3782,11 +3842,11 @@ def create_widgets():
         AeExposureMode_dropdown_selected = tk.StringVar()
         AeExposureMode_dropdown_selected.set("Normal")  # Set the initial value
         AeExposureMode_label = Label(exp_wb_frame, text='AE Exposure mode:', font=("Arial", FontSize-1), state=DISABLED)
-        AeExposureMode_label.grid(row=exp_wb_row, column=0, pady=1, sticky=E)
+        AeExposureMode_label.grid(row=exp_wb_row, column=0, padx=x_pad, pady=y_pad, sticky=E)
         AeExposureMode_dropdown = OptionMenu(exp_wb_frame, AeExposureMode_dropdown_selected,
                                              *AeExposureMode_dict.keys(), command=set_AeExposureMode)
         AeExposureMode_dropdown.config(takefocus=1, font=("Arial", FontSize-1), state=DISABLED)
-        AeExposureMode_dropdown.grid(row=exp_wb_row, columnspan=4, column=1, pady=1, sticky=W)
+        AeExposureMode_dropdown.grid(row=exp_wb_row, columnspan=2, column=1, padx=x_pad, pady=y_pad, sticky=W)
         as_tooltips.add(AeExposureMode_dropdown, "Sets the exposure mode of the AEC/AGC algorithm.")
         exp_wb_row+= 1
 
@@ -3795,28 +3855,28 @@ def create_widgets():
         AwbMode_dropdown_selected = tk.StringVar()
         AwbMode_dropdown_selected.set("Normal")  # Set the initial value
         AwbMode_label = Label(exp_wb_frame, text='AWB mode:', font=("Arial", FontSize-1), state=DISABLED)
-        AwbMode_label.grid(row=exp_wb_row, column=0, pady=1, sticky=E)
+        AwbMode_label.grid(row=exp_wb_row, column=0, padx=x_pad, pady=y_pad, sticky=E)
         AwbMode_dropdown = OptionMenu(exp_wb_frame, AwbMode_dropdown_selected,
                                              *AwbMode_dict.keys(), command=set_AwbMode)
         AwbMode_dropdown.config(takefocus=1, font=("Arial", FontSize-1), state=DISABLED)
-        AwbMode_dropdown.grid(row=exp_wb_row, columnspan=4, column=1, pady=1, sticky=W)
+        AwbMode_dropdown.grid(row=exp_wb_row, columnspan=2, column=1, padx=x_pad, pady=y_pad, sticky=W)
         as_tooltips.add(AwbMode_dropdown, "Sets the AWB mode of the AEC/AGC algorithm.")
         exp_wb_row+= 1
 
         # *****************************************
         # Frame to add brightness/contrast controls
         brightness_frame = LabelFrame(expert_frame, text="Brightness/Contrast", font=("Arial", FontSize-1))
-        brightness_frame.grid(row=0, column=1, padx=4, sticky='NSEW')
+        brightness_frame.grid(row=0, column=1, padx=x_pad, pady=y_pad, sticky='NSEW')
         brightness_row = 0
 
         # brightness
         brightness_label = tk.Label(brightness_frame, text='Brightness:', font=("Arial", FontSize-1))
-        brightness_label.grid(row=brightness_row, column=0, pady=1, sticky=E)
+        brightness_label.grid(row=brightness_row, column=0, padx=x_pad, pady=y_pad, sticky=E)
 
         brightness_value = tk.DoubleVar(value=0.0)  # Default value, overriden by configuration
         brightness_spinbox = DynamicSpinbox(brightness_frame, command=brightness_selection, width=8,
             textvariable=brightness_value, from_=-1.0, to=1.0, increment=0.1, font=("Arial", FontSize-1))
-        brightness_spinbox.grid(row=brightness_row, column=1, padx=5, pady=1, sticky=W)
+        brightness_spinbox.grid(row=brightness_row, column=1, padx=x_pad, pady=y_pad, sticky=W)
         brightness_validation_cmd = brightness_spinbox.register(brightness_validation)
         brightness_spinbox.configure(validate="key", validatecommand=(brightness_validation_cmd, '%P'))
         as_tooltips.add(brightness_spinbox, 'Adjusts the image brightness between -1.0 and 1.0, where -1.0 is very dark, 1.0 is very bright, and 0.0 is the default "normal" brightness.')
@@ -3825,12 +3885,12 @@ def create_widgets():
 
         # contrast
         contrast_label = tk.Label(brightness_frame, text='Contrast:', font=("Arial", FontSize-1))
-        contrast_label.grid(row=brightness_row, column=0, pady=1, sticky=E)
+        contrast_label.grid(row=brightness_row, column=0, padx=x_pad, pady=y_pad, sticky=E)
 
         contrast_value = tk.DoubleVar(value=1)  # Default value, overriden by configuration
         contrast_spinbox = DynamicSpinbox(brightness_frame, command=contrast_selection, width=8,
             textvariable=contrast_value, from_=0, to=32, increment=0.1, font=("Arial", FontSize-1))
-        contrast_spinbox.grid(row=brightness_row, column=1, padx=5, pady=1, sticky=W)
+        contrast_spinbox.grid(row=brightness_row, column=1, padx=x_pad, pady=y_pad, sticky=W)
         contrast_validation_cmd = contrast_spinbox.register(contrast_validation)
         contrast_spinbox.configure(validate="key", validatecommand=(contrast_validation_cmd, '%P'))
         as_tooltips.add(contrast_spinbox, 'Sets the contrast of the image between 0.0 and 32.0, where zero means "no contrast", 1.0 is the default "normal" contrast, and larger values increase the contrast proportionately.')
@@ -3839,12 +3899,12 @@ def create_widgets():
 
         # saturation
         saturation_label = tk.Label(brightness_frame, text='Saturation:', font=("Arial", FontSize-1))
-        saturation_label.grid(row=brightness_row, column=0, pady=1, sticky=E)
+        saturation_label.grid(row=brightness_row, column=0, padx=x_pad, pady=y_pad, sticky=E)
 
         saturation_value = tk.DoubleVar(value=1)  # Default value, overriden by configuration
         saturation_spinbox = DynamicSpinbox(brightness_frame, command=saturation_selection, width=8,
             textvariable=saturation_value, from_=0, to=32, increment=0.1, font=("Arial", FontSize-1))
-        saturation_spinbox.grid(row=brightness_row, column=1, padx=5, pady=1, sticky=W)
+        saturation_spinbox.grid(row=brightness_row, column=1, padx=x_pad, pady=y_pad, sticky=W)
         saturation_validation_cmd = saturation_spinbox.register(saturation_validation)
         saturation_spinbox.configure(validate="key", validatecommand=(saturation_validation_cmd, '%P'))
         as_tooltips.add(saturation_spinbox, 'Amount of colour saturation between 0.0 and 32.0, where zero produces greyscale images, 1.0 represents default "normal" saturation, and higher values produce more saturated colours.')
@@ -3853,12 +3913,12 @@ def create_widgets():
 
         # analogue_gain
         analogue_gain_label = tk.Label(brightness_frame, text='Analog. gain:', font=("Arial", FontSize-1))
-        analogue_gain_label.grid(row=brightness_row, column=0, pady=1, sticky=E)
+        analogue_gain_label.grid(row=brightness_row, column=0, padx=x_pad, pady=y_pad, sticky=E)
 
         analogue_gain_value = tk.DoubleVar(value=1)  # Default value, overriden by configuration
         analogue_gain_spinbox = DynamicSpinbox(brightness_frame, command=analogue_gain_selection, width=8,
             textvariable=analogue_gain_value, from_=0, to=32, increment=0.1, font=("Arial", FontSize-1))
-        analogue_gain_spinbox.grid(row=brightness_row, column=1, padx=5, pady=1, sticky=W)
+        analogue_gain_spinbox.grid(row=brightness_row, column=1, padx=x_pad, pady=y_pad, sticky=W)
         analogue_gain_validation_cmd = analogue_gain_spinbox.register(analogue_gain_validation)
         analogue_gain_spinbox.configure(validate="key", validatecommand=(analogue_gain_validation_cmd, '%P'))
         as_tooltips.add(analogue_gain_spinbox, "Analogue gain applied by the sensor.")
@@ -3867,12 +3927,12 @@ def create_widgets():
 
         # Sharpness, control to allow playing with the values and see the results
         sharpness_label = tk.Label(brightness_frame, text='Sharpness:', font=("Arial", FontSize-1))
-        sharpness_label.grid(row=brightness_row, column=0, pady=1, sticky=E)
+        sharpness_label.grid(row=brightness_row, column=0, padx=x_pad, pady=y_pad, sticky=E)
 
         sharpness_value = tk.DoubleVar(value=1)    # Default value, overridden by configuration if any
         sharpness_spinbox = DynamicSpinbox(brightness_frame, command=sharpness_selection, width=8,
             textvariable=sharpness_value, from_=0.0, to=16.0, increment=1, font=("Arial", FontSize-1))
-        sharpness_spinbox.grid(row=brightness_row, column=1, padx=5, pady=1, sticky=W)
+        sharpness_spinbox.grid(row=brightness_row, column=1, padx=x_pad, pady=y_pad, sticky=W)
         sharpness_validation_cmd = sharpness_spinbox.register(sharpness_validation)
         sharpness_spinbox.configure(validate="key", validatecommand=(sharpness_validation_cmd, '%P'))
         as_tooltips.add(sharpness_spinbox, 'Sets the image sharpness between 0.0 adn 16.0, where zero implies no additional sharpening is performed, 1.0 is the default "normal" level of sharpening, and larger values apply proportionately stronger sharpening.')
@@ -3881,12 +3941,12 @@ def create_widgets():
 
         # Exposure Compensation ('ExposureValue' in PiCamera2 controls
         exposure_compensation_label = tk.Label(brightness_frame, text='Exp. Comp.:', font=("Arial", FontSize-1))
-        exposure_compensation_label.grid(row=brightness_row, column=0, pady=1, sticky=E)
+        exposure_compensation_label.grid(row=brightness_row, column=0, padx=x_pad, pady=y_pad, sticky=E)
 
         exposure_compensation_value = tk.DoubleVar(value=0)    # Default value, overridden by configuration if any
         exposure_compensation_spinbox = DynamicSpinbox(brightness_frame, command=exposure_compensation_selection, width=8,
             textvariable=exposure_compensation_value, from_=-8.0, to=8.0, increment=0.1, font=("Arial", FontSize-1))
-        exposure_compensation_spinbox.grid(row=brightness_row, column=1, padx=5, pady=1, sticky=W)
+        exposure_compensation_spinbox.grid(row=brightness_row, column=1, padx=x_pad, pady=y_pad, sticky=W)
         exposure_compensation_validation_cmd = exposure_compensation_spinbox.register(exposure_compensation_validation)
         exposure_compensation_spinbox.configure(validate="key", validatecommand=(exposure_compensation_validation_cmd, '%P'))
         as_tooltips.add(exposure_compensation_spinbox, 'Exposure compensation value in "stops" (-8.0 to 8.0), which adjusts the target of the AEC/AGC algorithm. Positive values increase the target brightness, and negative values decrease it. Zero represents the base or "normal" exposure level.')
@@ -3895,64 +3955,56 @@ def create_widgets():
         # *********************************
         # Frame to add frame align controls
         frame_alignment_frame = LabelFrame(expert_frame, text="Frame align", font=("Arial", FontSize-1))
-        frame_alignment_frame.grid(row=0, column=2, padx=4, sticky='NSEW')
+        frame_alignment_frame.grid(row=0, column=2, padx=x_pad, pady=y_pad, sticky='NSEW')
         frame_align_row = 0
 
-        exp_wb_auto_label = tk.Label(frame_alignment_frame, text='Auto', width=4, font=("Arial", FontSize-1))
-        exp_wb_auto_label.grid(row=frame_align_row, column=2, padx=5, pady=1)
-        frame_align_row += 1
-
         # Spinbox to select MinFrameSteps on Arduino
-        steps_per_frame_label = tk.Label(frame_alignment_frame, text='Steps/frame:', font=("Arial", FontSize-1))
-        steps_per_frame_label.grid(row=frame_align_row, column=0, padx=5, pady=1, sticky=E)
+        auto_framesteps_enabled = tk.BooleanVar(value=True)
+        steps_per_frame_btn = tk.Checkbutton(frame_alignment_frame, variable=auto_framesteps_enabled, onvalue=True,
+                                             offvalue=False, font=("Arial", FontSize-1), command=steps_per_frame_auto,
+                                             selectcolor="pale green", text="Steps/Frame AUTO:", relief="raised",
+                                             indicatoron=False, width=18)
+        steps_per_frame_btn.grid(row=frame_align_row, column=0, sticky="EW")
+        as_tooltips.add(steps_per_frame_btn, "Toggle automatic steps/frame calculation.")
 
         steps_per_frame_value = tk.IntVar(value=250)    # Default to be overridden by configuration
-        steps_per_frame_spinbox = DynamicSpinbox(frame_alignment_frame, command=steps_per_frame_selection, width=8, readonlybackground='pale green',
+        steps_per_frame_spinbox = DynamicSpinbox(frame_alignment_frame, command=steps_per_frame_selection, width=4,
                                                  textvariable=steps_per_frame_value, from_=100, to=600, font=("Arial", FontSize-1))
-        steps_per_frame_spinbox.grid(row=frame_align_row, column=1, padx=2, pady=3, sticky=W)
+        steps_per_frame_spinbox.grid(row=frame_align_row, column=1, padx=x_pad, pady=y_pad, sticky=W)
         steps_per_frame_validation_cmd = steps_per_frame_spinbox.register(steps_per_frame_validation)
         steps_per_frame_spinbox.configure(validate="key", validatecommand=(steps_per_frame_validation_cmd, '%P'))
         as_tooltips.add(steps_per_frame_spinbox, "If automatic steps/frame is disabled, enter the number of motor steps required to advance one frame (100 to 600, depends on capstan diameter).")
         steps_per_frame_spinbox.bind("<FocusOut>", lambda event: steps_per_frame_selection())
 
-        auto_framesteps_enabled = tk.BooleanVar(value=True)
-        steps_per_frame_btn = tk.Checkbutton(frame_alignment_frame, variable=auto_framesteps_enabled, onvalue=True,
-                                             offvalue=False, font=("Arial", FontSize-1), command=steps_per_frame_auto)
-        steps_per_frame_btn.grid(row=frame_align_row, column=2, pady=3)
-        as_tooltips.add(steps_per_frame_btn, "Toggle automatic steps/frame calculation.")
-
         frame_align_row += 1
 
         # Spinbox to select PTLevel on Arduino
-        pt_level_label = tk.Label(frame_alignment_frame, text='PT Level:', font=("Arial", FontSize-1))
-        pt_level_label.grid(row=frame_align_row, column=0, padx=5, pady=1, sticky=E)
+        auto_pt_level_enabled = tk.BooleanVar(value=True)
+        pt_level_btn = tk.Checkbutton(frame_alignment_frame, variable=auto_pt_level_enabled, onvalue=True,
+                                      offvalue=False, font=("Arial", FontSize-1),command=set_auto_pt_level,
+                                      selectcolor="pale green", text="PT Level AUTO:", relief="raised", indicatoron=False)
+        pt_level_btn.grid(row=frame_align_row, column=0, sticky="EW")
+        as_tooltips.add(pt_level_btn, "Toggle automatic photo-transistor level calculation.")
 
         pt_level_value = tk.IntVar(value=200)   # To be overridden by config
-        pt_level_spinbox = DynamicSpinbox(frame_alignment_frame, command=pt_level_selection, width=8, readonlybackground='pale green',
+        pt_level_spinbox = DynamicSpinbox(frame_alignment_frame, command=pt_level_selection, width=4,
             textvariable=pt_level_value, from_=20, to=900, font=("Arial", FontSize-1))
-        pt_level_spinbox.grid(row=frame_align_row, column=1, padx=2, pady=3, sticky=W)
+        pt_level_spinbox.grid(row=frame_align_row, column=1, padx=x_pad, pady=y_pad, sticky=W)
         pt_level_validation_cmd = pt_level_spinbox.register(pt_level_validation)
         pt_level_spinbox.configure(validate="key", validatecommand=(pt_level_validation_cmd, '%P'))
         as_tooltips.add(pt_level_spinbox, "If automatic photo-transistor is disabled, enter the level to be reached to determine detection of sprocket hole (20 to 900, depends on PT used and size of hole).")
         pt_level_spinbox.bind("<FocusOut>", lambda event: pt_level_selection())
 
-        auto_pt_level_enabled = tk.BooleanVar(value=True)
-        pt_level_btn = tk.Checkbutton(frame_alignment_frame, variable=auto_pt_level_enabled,
-                                      onvalue=True, offvalue=False, font=("Arial", FontSize-1),
-                                      command=set_auto_pt_level)
-        pt_level_btn.grid(row=frame_align_row, column=2, pady=3)
-        as_tooltips.add(pt_level_btn, "Toggle automatic photo-transistor level calculation.")
-
         frame_align_row += 1
 
         # Spinbox to select Frame Fine Tune on Arduino
         frame_fine_tune_label = tk.Label(frame_alignment_frame, text='Fine tune:', font=("Arial", FontSize-1))
-        frame_fine_tune_label.grid(row=frame_align_row, column=0, padx=5, pady=1, sticky=E)
+        frame_fine_tune_label.grid(row=frame_align_row, column=0, padx=x_pad, pady=y_pad, sticky=E)
 
         frame_fine_tune_value = tk.IntVar(value=50)   # To be overridden by config
-        frame_fine_tune_spinbox = DynamicSpinbox(frame_alignment_frame, command=frame_fine_tune_selection, width=8, readonlybackground='pale green',
+        frame_fine_tune_spinbox = DynamicSpinbox(frame_alignment_frame, command=frame_fine_tune_selection, width=4, readonlybackground='pale green',
                         textvariable=frame_fine_tune_value, from_=5, to=95, increment=5, font=("Arial", FontSize-1))
-        frame_fine_tune_spinbox.grid(row=frame_align_row, column=1, padx=2, pady=3, sticky=W)
+        frame_fine_tune_spinbox.grid(row=frame_align_row, column=1, padx=x_pad, pady=y_pad, sticky=W)
         fine_tune_validation_cmd = frame_fine_tune_spinbox.register(fine_tune_validation)
         frame_fine_tune_spinbox.configure(validate="key", validatecommand=(fine_tune_validation_cmd, '%P'))
         as_tooltips.add(frame_fine_tune_spinbox, "Fine tune frame detection: Shift frame detection threshold up of down (5 to 95% of PT amplitude).")
@@ -3961,12 +4013,12 @@ def create_widgets():
 
         # Spinbox to select Extra Steps on Arduino
         frame_extra_steps_label = tk.Label(frame_alignment_frame, text='Extra Steps:', font=("Arial", FontSize-1))
-        frame_extra_steps_label.grid(row=frame_align_row, column=0, padx=5, pady=1, sticky=E)
+        frame_extra_steps_label.grid(row=frame_align_row, column=0, padx=x_pad, pady=y_pad, sticky=E)
 
         frame_extra_steps_value = tk.IntVar(value=0)  # To be overridden by config
-        frame_extra_steps_spinbox = DynamicSpinbox(frame_alignment_frame, command=frame_extra_steps_selection, width=8, readonlybackground='pale green',
+        frame_extra_steps_spinbox = DynamicSpinbox(frame_alignment_frame, command=frame_extra_steps_selection, width=4, readonlybackground='pale green',
                         textvariable=frame_extra_steps_value, from_=-30, to=30, font=("Arial", FontSize-1))
-        frame_extra_steps_spinbox.grid(row=frame_align_row, column=1, padx=2, pady=3, sticky=W)
+        frame_extra_steps_spinbox.grid(row=frame_align_row, column=1, padx=x_pad, pady=y_pad, sticky=W)
         extra_steps_validation_cmd = frame_extra_steps_spinbox.register(extra_steps_validation)
         frame_extra_steps_spinbox.configure(validate="key", validatecommand=(extra_steps_validation_cmd, '%P'))
         as_tooltips.add(frame_extra_steps_spinbox, "Unconditionally advances/detects the frame n steps after/before detection (n between -30 and 30). Negative values can help if film gate is not correctly positioned.")
@@ -3975,15 +4027,15 @@ def create_widgets():
         # ***************************************************
         # Frame to add stabilization controls (speed & delay)
         speed_quality_frame = LabelFrame(expert_frame, text="Frame stabilization", font=("Arial", FontSize-1))
-        speed_quality_frame.grid(row=1, column=2, padx=4, sticky='NSEW')
+        speed_quality_frame.grid(row=1, column=2, padx=x_pad, pady=y_pad, sticky='NSEW')
 
         # Spinbox to select Speed on Arduino (1-10)
         scan_speed_label = tk.Label(speed_quality_frame, text='Scan Speed:', font=("Arial", FontSize-1))
-        scan_speed_label.grid(row=0, column=0, padx=3, pady=1, sticky=E)
+        scan_speed_label.grid(row=0, column=0, padx=x_pad, pady=y_pad, sticky=E)
         scan_speed_value = tk.IntVar(value=5)   # Default value, overriden by configuration
-        scan_speed_spinbox = DynamicSpinbox(speed_quality_frame, command=scan_speed_selection, width=8,
+        scan_speed_spinbox = DynamicSpinbox(speed_quality_frame, command=scan_speed_selection, width=4,
                     textvariable=scan_speed_value, from_=1, to=10, font=("Arial", FontSize-1))
-        scan_speed_spinbox.grid(row=0, column=1, padx=4, pady=3, sticky=W)
+        scan_speed_spinbox.grid(row=0, column=1, padx=x_pad, pady=y_pad, sticky=W)
         scan_speed_validation_cmd = scan_speed_spinbox.register(scan_speed_validation)
         scan_speed_spinbox.configure(validate="key", validatecommand=(scan_speed_validation_cmd, '%P'))
         as_tooltips.add(scan_speed_spinbox, "Select scan speed from 1 (slowest) to 10 (fastest).A speed of 5 is usually a good compromise between speed and good frame position detection.")
@@ -3991,11 +4043,11 @@ def create_widgets():
 
         # Display entry to adjust capture stabilization delay (100 ms by default)
         stabilization_delay_label = tk.Label(speed_quality_frame, text='Stabilization\ndelay (ms):', font=("Arial", FontSize-1))
-        stabilization_delay_label.grid(row=1, column=0, padx=4, pady=1, sticky=E)
+        stabilization_delay_label.grid(row=1, column=0, padx=x_pad, pady=y_pad, sticky=E)
         stabilization_delay_value = tk.IntVar(value=100)    # default value, overriden by configuration
-        stabilization_delay_spinbox = DynamicSpinbox(speed_quality_frame, command=stabilization_delay_selection, width=8,
+        stabilization_delay_spinbox = DynamicSpinbox(speed_quality_frame, command=stabilization_delay_selection, width=4,
                     textvariable=stabilization_delay_value, from_=0, to=1000, increment=10, font=("Arial", FontSize-1))
-        stabilization_delay_spinbox.grid(row=1, column=1, padx=4, pady=3, sticky=W)
+        stabilization_delay_spinbox.grid(row=1, column=1, padx=x_pad, pady=y_pad, sticky=W)
         stabilization_delay_validation_cmd = stabilization_delay_spinbox.register(stabilization_delay_validation)
         stabilization_delay_spinbox.configure(validate="key", validatecommand=(stabilization_delay_validation_cmd, '%P'))
         as_tooltips.add(stabilization_delay_spinbox, "Delay between frame detection and snapshot trigger. 100ms is a good compromise, lower values might cause blurry captures.")
@@ -4003,34 +4055,33 @@ def create_widgets():
 
     if ExperimentalMode:
         experimental_frame = LabelFrame(extended_frame, text='Experimental Area', font=("Arial", FontSize-1))
-        experimental_frame.pack(side=LEFT, padx=5, ipadx=5, pady=5, expand=True, fill='y')
+        experimental_frame.pack(side=LEFT, padx=x_pad, pady=y_pad, expand=True, fill='y')
         #experimental_frame.place(relx=0.75, rely=0.5, anchor="center")
 
         # Frame to add HDR controls (on/off, exp. bracket, position, auto-adjust)
         hdr_frame = LabelFrame(experimental_frame, text="Multi-exposure fusion", font=("Arial", FontSize-1))
-        #hdr_frame.grid(row=0, column=1, padx=4, pady=4, sticky='NSEW')
-        hdr_frame.pack(side=LEFT, padx=5, pady=2, ipady=5, fill='both', expand=True)
+        hdr_frame.pack(side=LEFT, fill='both', padx=x_pad, pady=y_pad, expand=True)
         hdr_row = 0
         hdr_capture_active = tk.BooleanVar(value=HdrCaptureActive)
         hdr_capture_active_checkbox = tk.Checkbutton(hdr_frame, text=' Active', height=1,
                                                      variable=hdr_capture_active, onvalue=True, offvalue=False,
                                                      command=switch_hdr_capture, font=("Arial", FontSize-1))
-        hdr_capture_active_checkbox.grid(row=hdr_row, column=0, padx=2, pady=1, sticky=W)
+        hdr_capture_active_checkbox.grid(row=hdr_row, column=0, sticky=W)
         as_tooltips.add(hdr_capture_active_checkbox, "Activate multi-exposure scan. Three snapshots of each frame will be taken with different exposures, to be merged later by AfterScan.")
         hdr_viewx4_active = tk.BooleanVar(value=HdrViewX4Active)
         hdr_viewx4_active_checkbox = tk.Checkbutton(hdr_frame, text=' View X4', height=1,
                                                      variable=hdr_viewx4_active, onvalue=True, offvalue=False,
                                                      command=switch_hdr_viewx4, font=("Arial", FontSize-1), state=DISABLED)
-        hdr_viewx4_active_checkbox.grid(row=hdr_row, column=1, padx=2, pady=1, sticky=W)
+        hdr_viewx4_active_checkbox.grid(row=hdr_row, column=1, sticky=W)
         as_tooltips.add(hdr_viewx4_active_checkbox, "Alternate frame display during capture. Instead of displaying a single frame (the one in the middle), all three frames will be displayed sequentially.")
         hdr_row += 1
 
         hdr_min_exp_label = tk.Label(hdr_frame, text='Lower exp. (ms):', font=("Arial", FontSize-1), state=DISABLED)
-        hdr_min_exp_label.grid(row=hdr_row, column=0, padx=2, pady=1, sticky=E)
+        hdr_min_exp_label.grid(row=hdr_row, column=0, padx=x_pad, pady=y_pad, sticky=E)
         hdr_min_exp_value = tk.IntVar(value=hdr_lower_exp)
         hdr_min_exp_spinbox = DynamicSpinbox(hdr_frame, command=hdr_min_exp_selection, width=8, readonlybackground='pale green',
             textvariable=hdr_min_exp_value, from_=hdr_lower_exp, to=999, increment=1, font=("Arial", FontSize-1), state=DISABLED)
-        hdr_min_exp_spinbox.grid(row=hdr_row, column=1, padx=2, pady=1, sticky=W)
+        hdr_min_exp_spinbox.grid(row=hdr_row, column=1, padx=x_pad, pady=y_pad, sticky=W)
         hdr_min_exp_validation_cmd = hdr_min_exp_spinbox.register(hdr_min_exp_validation)
         hdr_min_exp_spinbox.configure(validate="key", validatecommand=(hdr_min_exp_validation_cmd, '%P'))
         as_tooltips.add(hdr_min_exp_spinbox, "When multi-exposure enabled, lower value of the exposure bracket.")
@@ -4038,11 +4089,11 @@ def create_widgets():
         hdr_row +=1
 
         hdr_max_exp_label = tk.Label(hdr_frame, text='Higher exp. (ms):', font=("Arial", FontSize-1), state=DISABLED)
-        hdr_max_exp_label.grid(row=hdr_row, column=0, padx=2, pady=1, sticky=E)
+        hdr_max_exp_label.grid(row=hdr_row, column=0, padx=x_pad, pady=y_pad, sticky=E)
         hdr_max_exp_value = tk.IntVar(value=hdr_higher_exp)
         hdr_max_exp_spinbox = DynamicSpinbox(hdr_frame, command=hdr_max_exp_selection, width=8, readonlybackground='pale green',
             textvariable=hdr_max_exp_value, from_=2, to=1000, increment=1, font=("Arial", FontSize-1), state=DISABLED)
-        hdr_max_exp_spinbox.grid(row=hdr_row, column=1, padx=2, pady=1, sticky=W)
+        hdr_max_exp_spinbox.grid(row=hdr_row, column=1, padx=x_pad, pady=y_pad, sticky=W)
         hdr_max_exp_validation_cmd = hdr_max_exp_spinbox.register(hdr_max_exp_validation)
         hdr_max_exp_spinbox.configure(validate="key", validatecommand=(hdr_max_exp_validation_cmd, '%P'))
         as_tooltips.add(hdr_max_exp_spinbox, "When multi-exposure enabled, upper value of the exposure bracket.")
@@ -4050,11 +4101,11 @@ def create_widgets():
         hdr_row += 1
 
         hdr_bracket_width_label = tk.Label(hdr_frame, text='Bracket width (ms):', font=("Arial", FontSize-1), state=DISABLED)
-        hdr_bracket_width_label.grid(row=hdr_row, column=0, padx=2, pady=1, sticky=E)
+        hdr_bracket_width_label.grid(row=hdr_row, column=0, padx=x_pad, pady=y_pad, sticky=E)
         hdr_bracket_width_value = tk.IntVar(value=50)
         hdr_bracket_width_spinbox = DynamicSpinbox(hdr_frame, command=hdr_bracket_width_selection, width=8,
             textvariable=hdr_bracket_width_value, from_=hdr_min_bracket_width, to=hdr_max_bracket_width, increment=1, font=("Arial", FontSize-1), state=DISABLED)
-        hdr_bracket_width_spinbox.grid(row=hdr_row, column=1, padx=2, pady=1, sticky=W)
+        hdr_bracket_width_spinbox.grid(row=hdr_row, column=1, padx=x_pad, pady=y_pad, sticky=W)
         hdr_bracket_width_validation_cmd = hdr_bracket_width_spinbox.register(hdr_bracket_width_validation)
         hdr_bracket_width_spinbox.configure(validate="key", validatecommand=(hdr_bracket_width_validation_cmd, '%P'))
         as_tooltips.add(hdr_bracket_width_spinbox, "When multi-exposure enabled, width of the exposure bracket (useful for automatic mode).")
@@ -4062,11 +4113,11 @@ def create_widgets():
         hdr_row += 1
 
         hdr_bracket_shift_label = tk.Label(hdr_frame, text='Bracket shift (ms):', font=("Arial", FontSize-1), state=DISABLED)
-        hdr_bracket_shift_label.grid(row=hdr_row, column=0, padx=2, pady=1, sticky=E)
+        hdr_bracket_shift_label.grid(row=hdr_row, column=0, padx=x_pad, pady=y_pad, sticky=E)
         hdr_bracket_shift_value = tk.IntVar(value=0)
         hdr_bracket_shift_spinbox = DynamicSpinbox(hdr_frame, command=hdr_bracket_shift_selection, width=8,
             textvariable=hdr_bracket_shift_value, from_=-100, to=100, increment=10, font=("Arial", FontSize-1), state=DISABLED)
-        hdr_bracket_shift_spinbox.grid(row=hdr_row, column=1, padx=2, pady=1, sticky=W)
+        hdr_bracket_shift_spinbox.grid(row=hdr_row, column=1, padx=x_pad, pady=y_pad, sticky=W)
         hdr_bracket_shift_validation_cmd = hdr_bracket_shift_spinbox.register(hdr_bracket_shift_validation)
         hdr_bracket_shift_spinbox.configure(validate="key", validatecommand=(hdr_bracket_shift_validation_cmd, '%P'))
         as_tooltips.add(hdr_bracket_shift_spinbox, "When multi-exposure enabled, shift exposure bracket up or down from default position.")
@@ -4077,7 +4128,7 @@ def create_widgets():
         hdr_bracket_width_auto_checkbox = tk.Checkbutton(hdr_frame, text='Auto bracket', height=1,
                                               variable=hdr_bracket_auto, onvalue=True, offvalue=False,
                                               command=adjust_hdr_bracket_auto, font=("Arial", FontSize-1))
-        hdr_bracket_width_auto_checkbox.grid(row=hdr_row, column=0, padx=2, pady=1, sticky=W)
+        hdr_bracket_width_auto_checkbox.grid(row=hdr_row, column=0, sticky=W)
         as_tooltips.add(hdr_bracket_width_auto_checkbox, "Enable automatic multi-exposure: For each frame, ALT-Scann8 will retrieve the auto-exposure level reported by the RPi HQ camera, adn will use it for the middle exposure, calculating the lower/upper values according to the bracket defined.")
         hdr_row += 1
 
@@ -4085,23 +4136,21 @@ def create_widgets():
         hdr_merge_in_place_checkbox = tk.Checkbutton(hdr_frame, text='Merge in place', height=1,
                                               variable=hdr_merge_in_place, onvalue=True, offvalue=False,
                                               command=adjust_merge_in_place, font=("Arial", FontSize-1))
-        hdr_merge_in_place_checkbox.grid(row=hdr_row, column=0, padx=2, pady=1, sticky=W)
+        hdr_merge_in_place_checkbox.grid(row=hdr_row, column=0, sticky=W)
         as_tooltips.add(hdr_merge_in_place_checkbox, "Enable to perform Mertens merge on the Raspberry Pi, while encoding. Allow to make some use of the time spent waiting for the camera to adapt the exposure.")
 
         # Experimental miscellaneous sub-frame
         experimental_miscellaneous_frame = LabelFrame(experimental_frame, text='Miscellaneous', font=("Arial", FontSize-1))
-        experimental_miscellaneous_frame.pack(side=LEFT, padx=5, pady=2, ipady=5, fill='both', expand=True)
+        experimental_miscellaneous_frame.pack(side=LEFT, padx=x_pad, pady=y_pad, fill='both', expand=True)
 
         # Display entry to throttle Rwnd/FF speed
-        rwnd_speed_control_label = tk.Label(experimental_miscellaneous_frame,
-                                             text='RW/FF speed rpm):',
-                                             font=("Arial", FontSize-1))
-        rwnd_speed_control_label.grid(row=1, column=0, padx=2, sticky=E)
+        rwnd_speed_control_label = tk.Label(experimental_miscellaneous_frame, text='RW/FF speed:', font=("Arial", FontSize-1))
+        rwnd_speed_control_label.grid(row=0, column=0, padx=x_pad, pady=y_pad)
         rwnd_speed_control_value = tk.IntVar(value=round(60 / (rwnd_speed_delay * 375 / 1000000)))
-        rwnd_speed_control_spinbox = DynamicSpinbox(experimental_miscellaneous_frame, state='readonly', width=8,
+        rwnd_speed_control_spinbox = DynamicSpinbox(experimental_miscellaneous_frame, state='readonly', width=4,
                                                 command=rwnd_speed_control_selection, from_=40, to=800, increment=50,
                                                 textvariable=rwnd_speed_control_value, font=("Arial", FontSize-1))
-        rwnd_speed_control_spinbox.grid(row=1, column=1, padx=2, sticky=W)
+        rwnd_speed_control_spinbox.grid(row=0, column=1, padx=x_pad, pady=y_pad)
         rewind_speed_validation_cmd = rwnd_speed_control_spinbox.register(rewind_speed_validation)
         rwnd_speed_control_spinbox.configure(validate="key", validatecommand=(rewind_speed_validation_cmd, '%P'))
         as_tooltips.add(rwnd_speed_control_spinbox, "Speed up/slow down the RWND/FF speed.")
@@ -4109,52 +4158,52 @@ def create_widgets():
 
         # Damaged film helpers, to help handling damaged film (broken perforations)
         Damaged_film_frame = LabelFrame(experimental_miscellaneous_frame, text='Damaged film', font=("Arial", FontSize-1))
-        Damaged_film_frame.grid(row=2, column=0, columnspan=2, padx=4, sticky='')
+        Damaged_film_frame.grid(row=1, column=0, columnspan=2, padx=x_pad, pady=y_pad)
         # Checkbox to enable/disable manual scan
         Manual_scan_activated = tk.BooleanVar(value=ManualScanEnabled)
-        Manual_scan_checkbox = tk.Checkbutton(Damaged_film_frame, text='Enable manual scan', width=20, height=1,
+        Manual_scan_checkbox = tk.Checkbutton(Damaged_film_frame, text='Enable manual scan',
                                                variable=Manual_scan_activated, onvalue=True,
                                                offvalue=False,
                                                command=Manual_scan_activated_selection, font=("Arial", FontSize-1))
         Manual_scan_checkbox.pack(side=TOP)
         as_tooltips.add(Manual_scan_checkbox, "Enable manual scan (for films with very damaged sprocket holes). Lots of manual work, use it if everything else fails.")
         # Common area for buttons
-        Manual_scan_btn_frame = Frame(Damaged_film_frame, width=18, height=2)
+        Manual_scan_btn_frame = Frame(Damaged_film_frame)
         Manual_scan_btn_frame.pack(side=TOP)
 
         # Manual scan buttons
         manual_scan_advance_fraction_5_btn = Button(Manual_scan_btn_frame, text="+5", width=1, height=1, command=manual_scan_advance_frame_fraction_5,
                                 state=DISABLED, font=("Arial", FontSize-1))
-        manual_scan_advance_fraction_5_btn.pack(side=LEFT, ipadx=5, fill=Y)
+        manual_scan_advance_fraction_5_btn.pack(side=LEFT, fill=Y)
         as_tooltips.add(manual_scan_advance_fraction_5_btn, "Advance film by 5 motor steps.")
         manual_scan_advance_fraction_20_btn = Button(Manual_scan_btn_frame, text="+20", width=1, height=1, command=manual_scan_advance_frame_fraction_20,
                                 state=DISABLED, font=("Arial", FontSize-1))
-        manual_scan_advance_fraction_20_btn.pack(side=LEFT, ipadx=5, fill=Y)
+        manual_scan_advance_fraction_20_btn.pack(side=LEFT, fill=Y)
         as_tooltips.add(manual_scan_advance_fraction_20_btn, "Advance film by 20 motor steps.")
         manual_scan_take_snap_btn = Button(Manual_scan_btn_frame, text="Snap", width=1, height=1, command=manual_scan_take_snap,
                                  state=DISABLED, font=("Arial", FontSize-1))
-        manual_scan_take_snap_btn.pack(side=RIGHT, ipadx=5, fill=Y)
+        manual_scan_take_snap_btn.pack(side=RIGHT, fill=Y)
         as_tooltips.add(manual_scan_take_snap_btn, "Take snapshot of frame at current position, then tries to advance to next frame.")
 
         # Retreat movie button (slow backward through filmgate)
-        RetreatMovie_btn = Button(experimental_miscellaneous_frame, text="Movie Backward", width=20, height=1, command=retreat_movie,
-                                  activebackground='#f0f0f0', wraplength=100, relief=RAISED, font=("Arial", FontSize-1))
-        RetreatMovie_btn.grid(row=3, column=0, columnspan=2, padx=4, sticky='')
+        RetreatMovie_btn = Button(experimental_miscellaneous_frame, text="Movie Backward", command=retreat_movie,
+                                  activebackground='#f0f0f0', relief=RAISED, font=("Arial", FontSize-1))
+        RetreatMovie_btn.grid(row=2, column=0, columnspan=2, padx=x_pad, pady=y_pad)
         as_tooltips.add(RetreatMovie_btn, "Moves the film backwards. BEWARE: Requires manually rotating the source reels in left position in order to avoid film jamming at film gate.")
 
         # Unlock reels button (to load film, rewind, etc.)
-        Free_btn = Button(experimental_miscellaneous_frame, text="Unlock Reels", width=20, height=1, command=set_free_mode,
-                          activebackground='#f0f0f0', wraplength=100, relief=RAISED, font=("Arial", FontSize-1))
-        Free_btn.grid(row=4, column=0, columnspan=2, padx=4, sticky='')
+        Free_btn = Button(experimental_miscellaneous_frame, text="Unlock Reels", command=set_free_mode,
+                          activebackground='#f0f0f0', relief=RAISED, font=("Arial", FontSize-1))
+        Free_btn.grid(row=3, column=0, columnspan=2, padx=x_pad, pady=y_pad)
         as_tooltips.add(Free_btn, "Used to be a standard button in ALT-Scann8, removed since now motors are always unlocked when not performing any specific operation.")
 
         # Spinbox to select Preview module
         preview_module_label = tk.Label(experimental_miscellaneous_frame, text='Preview module:', font=("Arial", FontSize-1))
-        preview_module_label.grid(row=5, column=0, padx=3, pady=1, sticky=E)
+        preview_module_label.grid(row=4, column=0, padx=x_pad, pady=y_pad)
         preview_module_value = tk.IntVar(value=1)   # Default value, overriden by configuration
-        preview_module_spinbox = DynamicSpinbox(experimental_miscellaneous_frame, command=preview_module_selection, width=8,
+        preview_module_spinbox = DynamicSpinbox(experimental_miscellaneous_frame, command=preview_module_selection, width=2,
                     textvariable=preview_module_value, from_=1, to=50, font=("Arial", FontSize-1))
-        preview_module_spinbox.grid(row=5, column=1, padx=4, pady=3, sticky=W)
+        preview_module_spinbox.grid(row=4, column=1, padx=x_pad, pady=y_pad, sticky=W)
         preview_module_validation_cmd = preview_module_spinbox.register(preview_module_validation)
         preview_module_spinbox.configure(validate="key", validatecommand=(preview_module_validation_cmd, '%P'))
         as_tooltips.add(preview_module_spinbox, "Select preview display frequency (1 every n frames).")
@@ -4167,6 +4216,29 @@ def create_widgets():
                                                     AeMeteringMode_label, AeMeteringMode_dropdown,
                                                     AeExposureMode_label, AeExposureMode_dropdown,
                                                     AwbMode_label, AwbMode_dropdown])
+
+    # Adjust plotter size based on right  frames
+    win.update_idletasks()
+    plotter_width = integrated_plotter_frame.winfo_width() - 10
+    plotter_height = int(plotter_width/2)
+    plotter_canvas.config(width=plotter_width, height=plotter_height)
+    # Adjust canvas size based on height of lateral frames
+    win.update_idletasks()
+    PreviewHeight = max(top_left_area_frame.winfo_height(), top_right_area_frame.winfo_height()) - 20  # Compansate pady
+    PreviewWidth = int(PreviewHeight * 4/3)
+    draw_capture_canvas.config(width=PreviewWidth, height=PreviewHeight)
+    # Adjust holes size/position
+    FilmHoleHeightTop = int(PreviewHeight / 5.9)
+    FilmHoleHeightBottom = int(PreviewHeight / 3.7)
+    # Adjust main window size
+    # Prevent window resize
+    # Get screen size - maxsize gives the usable screen size
+    main_container.update_idletasks()
+    app_width = min(main_container.winfo_reqwidth(), screen_width-150)
+    app_height = min(main_container.winfo_reqheight(), screen_height-150)
+    win.minsize(app_width, app_height)
+    win.maxsize(app_width, app_height)
+    win.geometry(f'{app_width}x{app_height-20}')  # setting the size of the window
 
 
 def get_controller_version():
@@ -4186,11 +4258,12 @@ def main(argv):
     global LogLevel, LoggingMode
     global ALT_scann_init_done
     global CameraDisabled, DisableThreads
-    global ForceSmallSize, ForceBigSize
+    global FontSize, add_vertical_scrollbar
+    global keep_control_widgets_enabled
 
     go_disable_tooptips = False
 
-    opts, args = getopt.getopt(argv, "sexl:ph12nt")
+    opts, args = getopt.getopt(argv, "sexl:phntwf:b")
 
     for opt, arg in opts:
         if opt == '-s':
@@ -4203,16 +4276,18 @@ def main(argv):
             CameraDisabled = True
         elif opt == '-l':
             LoggingMode = arg
-        elif opt == '-1':
-            ForceSmallSize = True
-        elif opt == '-2':
-            ForceBigSize = True
+        elif opt == '-f':
+            FontSize = int(arg)
+        elif opt == '-b':
+            add_vertical_scrollbar = True
         elif opt == '-n':
             go_disable_tooptips = True
         elif opt == '-t':
             DisableThreads = True
         elif opt == '-p':
             PlotterMode = not PlotterMode
+        elif opt == '-w':
+            keep_control_widgets_enabled = not keep_control_widgets_enabled
         elif opt == '-h':
             print("ALT-Scann 8 Command line parameters")
             print("  -s             Start Simulated session")
@@ -4222,7 +4297,9 @@ def main(argv):
             print("  -d             Disable camera (for development purposes)")
             print("  -n             Disable Tooltips")
             print("  -t             Disable multi-threading")
-            print("  -1             Initiate on 'small screen' mode (resolution lower than than Full HD)")
+            print("  -f             Set default font size for UI (11 by default)")
+            print("  -b             Add scrollbars to UI (in case it does not fit)")
+            print("  -w             Keep control widgets enabled while scanning")
             print("  -l <log mode>  Set log level (standard Python values (DEBUG, INFO, WARNING, ERROR)")
             exit()
 
@@ -4240,10 +4317,6 @@ def main(argv):
     if go_disable_tooptips:
         as_tooltips.disable()
 
-    if ExpertMode or ExperimentalMode:
-        aux = int((win.winfo_width() - extended_frame.winfo_width())/2)
-        extended_frame.config(padx=aux)
-
     load_config_data()
     load_session_data()
 
@@ -4255,10 +4328,8 @@ def main(argv):
         logging.debug("Toggle experimental mode.")
     if CameraDisabled:
         logging.debug("Camera disabled.")
-    if ForceSmallSize:
-        logging.debug("Forces restricted window mode.")
-    if ForceBigSize:
-        logging.debug("Forces full window mode.")
+    if FontSize != 11:
+        logging.debug(f"Font size = {FontSize}")
     if DisableThreads:
         logging.debug("Threads disabled.")
     if PlotterMode:

--- a/ALT-Scann8-UserInterface.py
+++ b/ALT-Scann8-UserInterface.py
@@ -20,9 +20,9 @@ __copyright__ = "Copyright 2022-24, Juan Remirez de Esparza"
 __credits__ = ["Juan Remirez de Esparza"]
 __license__ = "MIT"
 __module__ = "ALT-Scann8"
-__version__ = "1.10.15"
-__date__ = "2024-03-02"
-__version_highlight__ = "AWB Mode enabled control"
+__version__ = "1.10.16"
+__date__ = "2024-03-03"
+__version_highlight__ = "Auto font size"
 __maintainer__ = "Juan Remirez de Esparza"
 __email__ = "jremirez@hotmail.com"
 __status__ = "Development"
@@ -161,7 +161,7 @@ FilmHoleHeightBottom = 0
 DeltaX = 0
 DeltaY = 0
 WinInitDone = False
-FontSize = 11
+FontSize = 0
 FolderProcess = 0
 LoggingMode = "INFO"
 LogLevel = 0
@@ -2678,6 +2678,7 @@ def create_main_window():
     global WinInitDone, as_tooltips
     global FilmHoleY_Top, FilmHoleY_Bottom, FilmHoleHeightTop, FilmHoleHeightBottom
     global screen_width, screen_height
+    resolution_font=[(629,6), (677,7), (728,8), (785,9), (831,10), (895,11), (956,12), (1005,13), (1045,14), (1103,15), (1168,16), (1220,17), (1273,18)]
 
     win = tkinter.Tk()  # creating the main window and storing the window object in 'win'
     if SimulatedRun:
@@ -2686,9 +2687,17 @@ def create_main_window():
         win.title('ALT-Scann8 v' + __version__)  # setting title of the window
     # Get screen size - maxsize gives the usable screen size
     screen_width, screen_height = win.maxsize()
-    # Set dimensions of UI elements adapted to screen size
-    if screen_height < 1000:
-        FontSize = 8
+    logging.info(f"Screen size: {screen_width}x{screen_height}")
+
+    # Determine optimal font size
+    if FontSize == 0:
+        FontSize = 5
+        for resfont in resolution_font:
+            if resfont[0] + 128 < screen_height:
+                FontSize = resfont[1]
+            else:
+                break
+        logging.info(f"Font size: {FontSize}")
     PreviewWidth = 700
     PreviewHeight = int(PreviewWidth/(4/3))
     app_width = PreviewWidth + 420
@@ -2715,9 +2724,6 @@ def create_main_window():
     if 'WindowPos' in SessionData:
         win.geometry(f"+{SessionData['WindowPos'].split('+', 1)[1]}")
 
-    logging.info(f"Screen size: {screen_width}x{screen_height}")
-    logging.info(f"Window size: {app_width}x{app_height+20}")
-
     # Catch closing with 'X' button
     win.protocol("WM_DELETE_WINDOW", exit_app)
 
@@ -2726,6 +2732,7 @@ def create_main_window():
 
     create_widgets()
 
+    logging.info(f"Window size: {app_width}x{app_height+20}")
 
     # Get Top window coordinates
     TopWinX = win.winfo_x()
@@ -4327,7 +4334,7 @@ def main(argv):
         logging.debug("Toggle experimental mode.")
     if CameraDisabled:
         logging.debug("Camera disabled.")
-    if FontSize != 11:
+    if FontSize != 0:
         logging.debug(f"Font size = {FontSize}")
     if DisableThreads:
         logging.debug("Threads disabled.")

--- a/ALT-Scann8-UserInterface.py
+++ b/ALT-Scann8-UserInterface.py
@@ -20,9 +20,9 @@ __copyright__ = "Copyright 2022-24, Juan Remirez de Esparza"
 __credits__ = ["Juan Remirez de Esparza"]
 __license__ = "MIT"
 __module__ = "ALT-Scann8"
-__version__ = "1.10.1"
+__version__ = "1.10.2"
 __date__ = "2024-02-25"
-__version_highlight__ = "Fragmented Preview"
+__version_highlight__ = "Fix disable tooltips"
 __maintainer__ = "Juan Remirez de Esparza"
 __email__ = "jremirez@hotmail.com"
 __status__ = "Development"
@@ -4207,7 +4207,7 @@ def main(argv):
         elif opt == '-2':
             ForceBigSize = True
         elif opt == '-n':
-            disable_tooltips()
+            go_disable_tooptips = True
         elif opt == '-t':
             DisableThreads = True
         elif opt == '-p':
@@ -4235,6 +4235,9 @@ def main(argv):
     load_persisted_data_from_disk()     # Read json file in memory, to be processed by 'load_session_data'
 
     tscann8_init()
+
+    if go_disable_tooptips:
+        as_tooltips.disable()
 
     if ExpertMode or ExperimentalMode:
         aux = int((win.winfo_width() - extended_frame.winfo_width())/2)

--- a/ALT-Scann8-UserInterface.py
+++ b/ALT-Scann8-UserInterface.py
@@ -20,9 +20,9 @@ __copyright__ = "Copyright 2022-24, Juan Remirez de Esparza"
 __credits__ = ["Juan Remirez de Esparza"]
 __license__ = "MIT"
 __module__ = "ALT-Scann8"
-__version__ = "1.10.14"
+__version__ = "1.10.15"
 __date__ = "2024-03-02"
-__version_highlight__ = "Customizable font size + Scrollable main window"
+__version_highlight__ = "AWB Mode enabled control"
 __maintainer__ = "Juan Remirez de Esparza"
 __email__ = "jremirez@hotmail.com"
 __status__ = "Development"
@@ -718,7 +718,7 @@ def set_auto_wb():
             camera.set_controls({"ColourGains": camera_colour_gains})
     arrange_widget_state(not AWB_enabled.get(), [auto_wb_wait_btn])
     arrange_widget_state(AWB_enabled.get(), [wb_red_spinbox, wb_blue_spinbox])
-
+    arrange_widget_state(not AWB_enabled.get(), [AwbMode_label, AwbMode_dropdown])
 
 
 def auto_white_balance_change_pause_selection():
@@ -2557,8 +2557,8 @@ def load_session_data():
         arrange_widget_state(not AE_enabled.get(), [auto_exposure_wait_btn,
                                                     AeConstraintMode_label, AeConstraintMode_dropdown,
                                                     AeMeteringMode_label, AeMeteringMode_dropdown,
-                                                    AeExposureMode_label, AeExposureMode_dropdown,
-                                                    AwbMode_label, AwbMode_dropdown])
+                                                    AeExposureMode_label, AeExposureMode_dropdown])
+        arrange_widget_state(not AWB_enabled.get(), [AwbMode_label, AwbMode_dropdown])
         arrange_widget_state(auto_pt_level_enabled.get(), [pt_level_spinbox])
         arrange_widget_state(auto_framesteps_enabled.get(), [steps_per_frame_spinbox])
     if ExperimentalMode:
@@ -2885,8 +2885,7 @@ def set_auto_exposure():
     arrange_widget_state(not AE_enabled.get(), [auto_exposure_wait_btn,
                                                 AeConstraintMode_label, AeConstraintMode_dropdown,
                                                 AeMeteringMode_label, AeMeteringMode_dropdown,
-                                                AeExposureMode_label, AeExposureMode_dropdown,
-                                                AwbMode_label, AwbMode_dropdown])
+                                                AeExposureMode_label, AeExposureMode_dropdown])
 
     if not SimulatedRun and not CameraDisabled:
         # Do not retrieve current gain values from Camera (capture_metadata) to prevent conflicts
@@ -4214,8 +4213,8 @@ def create_widgets():
         arrange_widget_state(not AE_enabled.get(), [auto_exposure_wait_btn,
                                                     AeConstraintMode_label, AeConstraintMode_dropdown,
                                                     AeMeteringMode_label, AeMeteringMode_dropdown,
-                                                    AeExposureMode_label, AeExposureMode_dropdown,
-                                                    AwbMode_label, AwbMode_dropdown])
+                                                    AeExposureMode_label, AeExposureMode_dropdown])
+        arrange_widget_state(not AWB_enabled.get(), [AwbMode_label, AwbMode_dropdown])
 
     # Adjust plotter size based on right  frames
     win.update_idletasks()


### PR DESCRIPTION
- Bugfix: 'AWB Mode' control was enabled/disabled based on AE, instead of AWB. Corrected.
- Automatic calculation of font size depending on screen size
- Keep manual WB values separated from AWB calculated ones
- Control widgets enabled while scanning by default. Opposite behavior with -w
- Refresh AE/AWB values as per 'preview module' setting
- Enforce preview module in all use cases