### PR TITLE
ALT-Scann8 user interface 1.11.5, ALT-Scann8 controller 1.1.3

### DIFF
--- a/ALT-Scann8-Controller.ino
+++ b/ALT-Scann8-Controller.ino
@@ -18,9 +18,9 @@ More info in README.md file
 #define __copyright__   "Copyright 2022-25, Juan Remirez de Esparza"
 #define __credits__     "Juan Remirez de Esparza"
 #define __license__     "MIT"
-#define __version__     "1.1.2"
-#define  __date__       "2025-01-30"
-#define  __version_highlight__  "Return controller version in API function RSP_VERSION_ID"
+#define __version__     "1.1.3"
+#define  __date__       "2025-02-05"
+#define  __version_highlight__  "Return number of steps required for detected frame (SCAN_FRAME_DETECTED)"
 #define __maintainer__  "Juan Remirez de Esparza"
 #define __email__       "jremirez@hotmail.com"
 #define __status__      "Development"
@@ -611,7 +611,7 @@ void loop() {
                         break;
                     case SCAN_FRAME_DETECTED:
                         ScanState = Sts_Idle; // Exit scan loop
-                        SendToRPi(RSP_FRAME_AVAILABLE, 0, 0);
+                        SendToRPi(RSP_FRAME_AVAILABLE, LastFrameSteps, 0);
                         break;
                     case SCAN_TERMINATION_REQUESTED:
                     case SCAN_FRAME_DETECTION_ERROR:

--- a/ALT-Scann8-UserInterface.py
+++ b/ALT-Scann8-UserInterface.py
@@ -20,9 +20,9 @@ __copyright__ = "Copyright 2022-25, Juan Remirez de Esparza"
 __credits__ = ["Juan Remirez de Esparza"]
 __license__ = "MIT"
 __module__ = "ALT-Scann8"
-__version__ = "1.11.3"
-__date__ = "2025-01-30"
-__version_highlight__ = "Retrieve controller version in API function RSP_VERSION_ID"
+__version__ = "1.11.4"
+__date__ = "2025-02-01"
+__version_highlight__ = "Display text box to replace QR code if library not loaded"
 __maintainer__ = "Juan Remirez de Esparza"
 __email__ = "jremirez@hotmail.com"
 __status__ = "Development"
@@ -823,7 +823,7 @@ def cmd_settings_popup_accept():
         send_arduino_command(CMD_ADJUST_MIN_FRAME_STEPS, int(CapstanDiameter*10))
     if LoggingMode != debug_level_selected.get():
         LoggingMode = debug_level_selected.get()
-        if not SimplifiedMode and qr_lib_installed:
+        if not SimplifiedMode:
             if LoggingMode == 'DEBUG':
                 refresh_ui = True   # To display qr code
             elif qr_code_frame != None:
@@ -859,6 +859,7 @@ def cmd_settings_popup_accept():
 
     if refresh_ui:
         create_main_window()
+        refresh_qr_code()
         widget_list_enable([id_RealTimeDisplay, id_RealTimeZoom, id_AutoStopEnabled])
         if ExpertMode:
             widget_list_enable([id_AutoWbEnabled, id_AutoExpEnabled, id_AutoPtLevelEnabled, id_AutoFrameStepsEnabled,
@@ -1092,6 +1093,7 @@ def generate_qr_code_info():
             f"File:{FileType}\n"
             f"Font:{FontSize}\n"
             f"Cpst:{CapstanDiameter}\n")
+    logging.debug(data)
     return data
 
 
@@ -1166,37 +1168,38 @@ def refresh_qr_code():
     global win
     global qr_image
 
-    if SimplifiedMode or not qr_lib_installed:
+    if SimplifiedMode or LoggingMode != 'DEBUG':
         return
-
-    if LoggingMode != 'DEBUG' or qr_code_canvas == None:
-        return
+    
     win.update_idletasks()
 
-    qr_img = generate_qr_code_image()
+    if qr_lib_installed:
+        qr_img = generate_qr_code_image()
 
-    size = min(qr_code_canvas.winfo_width(), qr_code_canvas.winfo_height())
-    print(f"({qr_code_canvas.winfo_width()},{qr_code_canvas.winfo_height()})")
+        size = min(qr_code_canvas.winfo_width(), qr_code_canvas.winfo_height())
 
-    # Get Pillow version number
-    major_version = int(PIL_Version.split('.')[0])
-    minor_version = int(PIL_Version.split('.')[1])
+        # Get Pillow version number
+        major_version = int(PIL_Version.split('.')[0])
+        minor_version = int(PIL_Version.split('.')[1])
 
-    # Choose resampling method based on Pillow version
-    if major_version > 8 or major_version == 8 and minor_version > 1:
-        resampling_method = Image.Resampling.LANCZOS
+        # Choose resampling method based on Pillow version
+        if major_version > 8 or major_version == 8 and minor_version > 1:
+            resampling_method = Image.Resampling.LANCZOS
+        else:
+            resampling_method = Image.ANTIALIAS
+        # Resize the image to fit within the canvas
+        qr_img = qr_img.resize((size, size), resampling_method)
+
+        qr_image = ImageTk.PhotoImage(qr_img)
+        # Convert the Image object into a Tkinter-compatible image object
+
+        # Draw the image on the canvas
+        qr_code_canvas.create_image(int((qr_code_canvas.winfo_width()-size)/2),
+                                    int((qr_code_canvas.winfo_height()-size)/2), anchor=tk.NW, image=qr_image)
     else:
-        resampling_method = Image.ANTIALIAS
-    # Resize the image to fit within the canvas
-    qr_img = qr_img.resize((size, size), resampling_method)
-
-    qr_image = ImageTk.PhotoImage(qr_img)
-    # Convert the Image object into a Tkinter-compatible image object
-
-    # Draw the image on the canvas
-    qr_code_canvas.create_image(int((qr_code_canvas.winfo_width()-size)/2),
-                                int((qr_code_canvas.winfo_height()-size)/2), anchor=tk.NW, image=qr_image)
-
+        qr_code_canvas.delete("all")
+        data = generate_qr_code_info()
+        qr_code_canvas.create_text(10, 10, anchor=tk.NW, text=data, font=f"Helvetica {7}")
 
 def set_base_folder():
     global BaseFolder, CurrentDir
@@ -2289,8 +2292,7 @@ def cmd_start_scan_simulated():
             tk.messagebox.showerror("Error!", "Folder " + CurrentDir + " does not  exist!")
             ScanOngoing = False
         else:
-            if qr_lib_installed:
-                refresh_qr_code()
+            refresh_qr_code()
             simulated_captured_frame_list = os.listdir(CurrentDir)
             simulated_captured_frame_list.sort()
             simulated_images_in_list = len(simulated_captured_frame_list)
@@ -2481,8 +2483,7 @@ def start_scan():
             logging.debug("Sending CMD_START_SCAN")
             send_arduino_command(CMD_START_SCAN)
 
-        if qr_lib_installed:
-            refresh_qr_code()
+        refresh_qr_code()
 
         # Invoke capture_loop a first time when scan starts
         win.after(5, capture_loop)
@@ -2825,8 +2826,8 @@ def arduino_listen_loop():  # Waits for Arduino communicated events and dispatch
             logging.info("Raspberry Pi Pico controller detected")
             Controller_version = "Pico "
         Controller_version += f"{ArduinoParam1//256}.{ArduinoParam2//256}.{ArduinoParam2%256}"
-        print(f"Controller version: {Controller_version}, {ArduinoParam1}, {ArduinoParam2}")
-        generate_qr_code_info()
+        win.title(f"ALT-Scann8 v{__version__} ({Controller_version})")  # setting title of the window
+        refresh_qr_code()
     elif ArduinoTrigger == RSP_FORCE_INIT:  # Controller reloaded, sent init sequence again
         logging.debug("Controller requested to reinit")
         reinit_controller()
@@ -3616,7 +3617,7 @@ def create_main_window():
     if SimulatedRun:
         win.wm_title(string='ALT-Scann8 v' + __version__ + ' ***  SIMULATED RUN, NOT OPERATIONAL ***')
     else:
-        win.title('ALT-Scann8 v' + __version__)  # setting title of the window
+        win.title(f"ALT-Scann8 v{__version__} ({Controller_version})")  # setting title of the window
     # Get screen size - maxsize gives the usable screen size
     screen_width = win.winfo_screenwidth()
     screen_height = win.winfo_screenheight()
@@ -3667,8 +3668,6 @@ def create_main_window():
     create_widgets()
 
     logging.info(f"Window size: {app_width}x{app_height + 20}")
-
-    refresh_qr_code()
 
     # Get Top window coordinates
     TopWinX = win.winfo_x()
@@ -5103,18 +5102,18 @@ def create_widgets():
                                                        'it. Zero represents the base or "normal" exposure level.')
         exposure_compensation_spinbox.bind("<FocusOut>", lambda event: cmd_exposure_compensation_selection())
 
-        # QR Code
-        if qr_lib_installed and LoggingMode == 'DEBUG':
+        # QR Code - Create Canvas to display QR code or text info (if QR Code library not available)
+        if LoggingMode == 'DEBUG':
             qr_code_frame = LabelFrame(expert_frame, text="Debug Info", font=("Arial", FontSize - 1),
-                                          name='qr_code_frame')
+                                            name='qr_code_frame')
             qr_code_frame.grid(row=1, rowspan=2, column=2, padx=x_pad, pady=y_pad, sticky='NSEW')
             qr_code_canvas = Canvas(qr_code_frame, bg='white', name='qr_code_canvas', width=1, height=1)
             qr_code_canvas.pack(side=TOP, expand=True, fill='both')
             qr_code_canvas.bind("<Button-1>", display_qr_code_info)
+            as_tooltips.add(qr_code_canvas, "Click to display debug information.")
         else:
             qr_code_canvas = None
             qr_code_frame = None
-
         # *********************************
         # Frame to add frame align controls
         frame_alignment_frame = LabelFrame(expert_frame, text="Frame align", font=("Arial", FontSize - 1),
@@ -5656,6 +5655,8 @@ def main(argv):
         arduino_listen_loop()
 
     ALT_scann_init_done = True
+
+    refresh_qr_code()
 
     # *** ALT-Scann8 load complete ***
     if hw_panel_installed:


### PR DESCRIPTION
- Move log files to dedicated subfolder ('Logs')
- Add scan error counter in UI (number of steps required to detect frame differ more than 20% from calculated number based on capstan diameter)
- Add separate log file for scan errors (''ScanErrors.YYYYMMDD.log) containing frames that failed the check, along with the number of steps done to detect it