### PR TITLE
Merging latest changes from develop

### DIFF
--- a/FrameAlignmentChecker.py
+++ b/FrameAlignmentChecker.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python
+"""
+ALT-Scann8 Utility - Frame Alignment Checker
+
+This tool is standalone utility to check frames already scanned to see if the ar eproperly aligned or not
+
+Licensed under a MIT LICENSE.
+"""
+
+__author__ = 'Juan Remirez de Esparza'
+__copyright__ = "Copyright 2025, Juan Remirez de Esparza"
+__credits__ = ["Juan Remirez de Esparza"]
+__license__ = "MIT"
+__module__ = "ALT-Scann8 - Frame Alignment Checker"
+__version__ = "1.0.0"
+__date__ = "2025-02-10"
+__version_highlight__ = "First release of Frame Alignment Checker"
+__maintainer__ = "Juan Remirez de Esparza"
+__email__ = "jremirez@hotmail.com"
+__status__ = "Development"
+
+# ######### Imports section ##########
+
+import tkinter as tk
+from tkinter import filedialog, scrolledtext, Spinbox, ttk
+import os
+import cv2
+import numpy as np
+
+
+def is_frame_centered(image_path, film_type ='S8', threshold=10, slice_width=10):
+    # Read the image
+    img = cv2.imread(image_path, cv2.IMREAD_GRAYSCALE)
+    if img is None:
+        raise ValueError("Could not read the image")
+
+    # Convert to pure black and white (binary image)
+    _, binary_img = cv2.threshold(img, 200, 255, cv2.THRESH_BINARY)
+    # _, binary_img = cv2.threshold(img, 0, 255, cv2.THRESH_BINARY+cv2.THRESH_OTSU)
+
+    # Get dimensions of the binary image
+    height, width = binary_img.shape
+
+    # Slice only the left part of the image
+    if slice_width > width:
+        raise ValueError("Slice width exceeds image width")
+    sliced_image = binary_img[:, :slice_width]
+
+    # Calculate the middle horizontal line
+    middle = height // 2
+
+    # Calculate margin
+    margin = height*threshold//100
+
+    # Sum along the width to get a 1D array representing white pixels at each height
+    height_profile = np.sum(sliced_image, axis=1)
+    
+    # Find where the sum is non-zero (white areas)
+    if film_type == 'S8':
+        white_heights = np.where(height_profile > 0)[0]
+    else:
+        white_heights = np.where(height_profile == 0)[0]
+    
+    areas = []
+    start = None
+    previous = None
+    for i in white_heights:
+        if start is None:
+            start = i
+        if previous is not None and i-previous != 1:
+            if start is not None:
+                areas.append((start, previous - 1))
+            start = i
+        previous = i
+    if start is not None:  # Add the last area if it exists
+        areas.append((start, white_heights[-1]))
+    
+    results = []
+    for start, end in areas:
+        center = (start + end) // 2
+        results.append(center)
+    if len(results) == 1 and results[0] >= middle - margin and results[0] <= middle + margin:
+        return True, middle, len(results), results[0], middle - margin, middle + margin
+    else:
+        return False, middle, len(results), 0, middle - margin, middle + margin
+
+
+# Flag to control the processing loop
+processing = False
+
+# Example function to process images. Replace this with your actual function.
+def process_image(image_path, film_type, threshold):
+    if not processing:
+        return "Processing was interrupted"
+    return f"Processed image: {image_path}"
+
+def select_folder():
+    global processing
+    folder_selected = filedialog.askdirectory()
+    if folder_selected:
+        result_text.delete(1.0, tk.END)  # Clear previous results
+        threshold = int(spinbox.get())  # Get the value from Spinbox
+        film_type = film_type_var.get()  # Get the selected mode
+        processing = True
+        stop_button.config(state=tk.NORMAL)  # Enable stop button
+        root.after(0, process_images_in_folder, folder_selected, film_type, threshold)
+    else:
+        result_text.insert(tk.END, "No folder selected\n")
+
+def process_images_in_folder(folder_path, film_type, threshold):
+    global processing
+    sorted_filenames = sorted(os.listdir(folder_path))
+    
+    total_files = len([f for f in sorted_filenames if f.lower().endswith(('.png', '.jpg', '.jpeg', '.gif', '.bmp'))])
+    processed_files = 0
+    misaligned_counter = 0
+
+    for filename in sorted_filenames:
+        if not processing:  # Check if processing was stopped
+            break
+        if filename.lower().endswith(('.png', '.jpg', '.jpeg', '.gif', '.bmp')):
+            image_path = os.path.join(folder_path, filename)
+            centered = is_frame_centered(image_path, film_type, threshold)[0]
+            if not centered:
+                result_text.insert(tk.END, f"Misaligned Frame detected: {image_path}\n")
+                misaligned_counter += 1
+            # Update progress
+            processed_files += 1
+            progress = (processed_files / total_files) * 100 if total_files > 0 else 0
+            progress_bar['value'] = progress
+            root.update_idletasks()
+            root.update()
+    
+    if processing:
+        result_text.insert(tk.END, f"Processing completed (using threshold = {threshold})!\n")
+    else:
+        result_text.insert(tk.END, "Processing stopped by user.\n")
+    if processed_files > 0:
+        if misaligned_counter > 0:
+            result_text.insert(tk.END, f"{processed_files} frames verified, {misaligned_counter} are not correctly aligned ({misaligned_counter*100//processed_files}%).\n")
+        else:
+            result_text.insert(tk.END, f"{processed_files} frames verified, all are correctly aligned!!!")
+    # Scroll to the bottom
+    result_text.see(tk.END)
+    stop_button.config(state=tk.DISABLED)  # Disable stop button after processing ends or is stopped
+    processing = False
+
+def stop_processing():
+    global processing
+    processing = False
+
+def on_closing():
+    global processing
+    if processing:
+        if tk.messagebox.askokcancel("Quit", "Processing is ongoing. Do you want to stop it and quit?"):
+            processing = False
+            root.destroy()
+    else:
+        if tk.messagebox.askokcancel("Quit", "Do you want to quit?"):
+            root.destroy()
+
+# Main window setup
+root = tk.Tk()
+root.title(f"ALT-Scann8 utility - Standalone Frame Alignment Checker (v{__version__})")
+
+# Button to select folder
+select_button = tk.Button(root, text="Select Folder", command=select_folder)
+select_button.pack(pady=5)
+
+# Frame for aligning threshold label
+threshold_frame = tk.Frame(root)
+threshold_frame.pack(pady=5)
+# Label and Spinbox for selecting a threshold
+tk.Label(threshold_frame, text="Threshold:").pack(side=tk.LEFT, padx=(20, 5), pady=5)
+spinbox = Spinbox(threshold_frame, from_=0, to=100, width=5, textvariable=tk.StringVar(value='10'))
+spinbox.pack(side=tk.LEFT, pady=5)
+
+# Frame for aligning radio buttons horizontally
+radio_frame = tk.Frame(root)
+radio_frame.pack(pady=5)
+film_type_var = tk.StringVar(value='S8')  # Default value
+tk.Radiobutton(radio_frame, text='S8', variable=film_type_var, value='S8').pack(side=tk.LEFT)
+tk.Radiobutton(radio_frame, text='R8', variable=film_type_var, value='R8').pack(side=tk.LEFT)
+
+# Scrolled text widget for displaying results
+result_text = scrolledtext.ScrolledText(root, width=40, height=10)
+result_text.pack(fill=tk.BOTH, expand=True)
+
+# Progress bar
+progress_bar = ttk.Progressbar(root, length=200, mode='determinate')
+progress_bar.pack(pady=5)
+
+# Frame for aligning stop and close buttons horizontally
+button_frame = tk.Frame(root)
+button_frame.pack(pady=5)
+stop_button = tk.Button(button_frame, text="Stop", command=stop_processing, state=tk.DISABLED)
+stop_button.pack(side=tk.LEFT, padx=5)
+close_button = tk.Button(button_frame, text="Close", command=on_closing)
+close_button.pack(side=tk.LEFT, padx=5)
+
+# Set up window close protocol
+root.protocol("WM_DELETE_WINDOW", on_closing)
+
+# Function to update the widget size on window resize
+def on_resize(event):
+    # We'll resize the frame and the text widget will follow
+    root.update_idletasks()
+
+# Bind the resize event to the update function
+root.bind("<Configure>", on_resize)
+
+# Start the GUI
+root.mainloop()
+
+


### PR DESCRIPTION
ALT-Scann8 User Interface 1.11.9
  * Move 'scan errors' counter to Frame align section, also rename to 'frame errors'
ALT-Scann8 User Interface 1.11.10
  * Change width taken by some widgets to prevent lower control area to be wider than upper
ALT-Scann8 User Interface 1.11.11
  * For existing config files, transform legacy name CentreWeighted to CentreWgt
ALT-Scann8 User Interface 1.11.12
  * Remove test data from UI after latest changes
ALT-Scann8 User Interface 1.11.13
  * Check frame misalignment also in DNG files (**Untested**)
    * This feature requires a couple of libraries (rawpy, imageio) which have to be installed via pip, which I prefer not to do in my system. If you give it a try and it works, let me know and I'll remove the warning.   
  * Fix bug when initializing widget when HDR Auto bracket enabled
ALT-Scann8 User Interface 1.11.14
  * More accurate detection of misaligned frames by using a new method. It handles both S8/R8, and the tolerance can be adjusted

# Added new utility FrameAlignmentChecker (to check alignment of existing frames)
FrameAlignmentChecker 1.0.0
  * First version of this utility. Can be used to check an existing set of frames to determine whether they are properly aligned. A threshold can be set to tune the sensitivity, and at the end, the proportion of misaligned frames is shown (the files with misaligned framer are listed as processing goes on).
FrameAlignmentChecker 1.0.1
  * For misaligned frames, display number of pixels by which target is missed (to asses severity)
  * Display process duration when done
  * Scroll to bottom of text box while process is ongoing
  * Prevent user from typing in results test box
