### PR TITLE
Add DNG frame check support - ALT-Scann8 User Interface 1.11.17, FrameAlignmentChecker 1.0.6

### DIFF
--- a/ALT-Scann8-UserInterface.py
+++ b/ALT-Scann8-UserInterface.py
@@ -20,7 +20,7 @@ __copyright__ = "Copyright 2022-25, Juan Remirez de Esparza"
 __credits__ = ["Juan Remirez de Esparza"]
 __license__ = "MIT"
 __module__ = "ALT-Scann8"
-__version__ = "1.11.15"
+__version__ = "1.11.16"
 __date__ = "2025-02-11"
 __version_highlight__ = "Integrate latest version of is_frame_centered function, same as in FrameAlignmentCheck"
 __maintainer__ = "Juan Remirez de Esparza"
@@ -1616,16 +1616,17 @@ def is_frame_centered(image_path, film_type ='S8', threshold=10, slice_width=10)
     
     areas = []
     start = None
+    min_gap_size = int(height*0.08)  # minimum hole height is around 8% of the frame height
     previous = None
     for i in white_heights:
         if start is None:
             start = i
-        if previous is not None and i-previous > 20:    # 20 is minimum number of consecutive pixels to skip small gaps
-            if start is not None:
+        if previous is not None and i-previous > 1: # end of first ares, check size
+            if previous-start > min_gap_size:  # min_gap_size is minimum number of consecutive pixels to skip small gaps
                 areas.append((start, previous - 1))
             start = i
         previous = i
-    if start is not None:  # Add the last area if it exists
+    if start is not None and white_heights[-1]-start > min_gap_size:  # Add the last area if it exists
         areas.append((start, white_heights[-1]))
     
     result = 0
@@ -1643,9 +1644,9 @@ def is_frame_centered(image_path, film_type ='S8', threshold=10, slice_width=10)
         if result >= middle - margin and result <= middle + margin:
             return True, 0
         elif result < middle - margin:
-            return False, (middle - margin) - result
+            return False, -(middle - result)
         elif result > middle + margin:
-            return False, result - (middle + margin)
+            return False, result - middle
     return False, -1
 
 


### PR DESCRIPTION
ALT-Scann8 User Interface 1.11.17 
  * Enable frame alignment checking for DNG files
    * This feature requires using the rawpy library, for which and I have not found a (simple) way to install it at system level in the Raspberry Pi, so needs to be installed using a python virtual environment. Here are the steps to do so:
      * python -m venv --system-site-packages altscann8 # Creates a virtual environment named 'altscann8'. 'system-site-packages' is to allow the venv to access packages installed at system level
      * source altscann8/bin/activate # Activates the virtual environment just created
      * pip install rawpy # Install the rawpy library, required to handle DNG files in python 
      * pip install numpy==1.26.4 # Required as when installing rawpy, pip will install a newer version of numpy that is not compatible with PiCamera2. Maybe just uninstalling the newer version on Numpy in the venv will also work, but I have not tested it
      * python /home/juan/ALT-Scann8/ALT-Scann8-UserInterface.py # At this point ALT-Scann8 can be run, and it should be able to detect misalignments in DNG files
      * deactivate # Exits the python irtual environment, returning to the standard command prompt
      * To run ALT-Scann8 later on, remember you'll need always to activate the venv before, otherwise frame alignment detection will not be available for DNG files
FrameAlignmentChecker 1.0.5
  * Add support for DNG files - Needs rawpy library
  * Make zoom level persistent when opening new images 
FrameAlignmentChecker 1.0.6
  * Image viewer: Replace opencv imshow with a tkinter popup window: Allow to display several windows at once and does not interfere with python mainloop