### PR TITLE
Fix Focus View showing (and leaking) a 1.5x center crop on recent kernels

### DIFF
--- a/ALT-Scann8.py
+++ b/ALT-Scann8.py
@@ -2216,7 +2216,8 @@ def update_real_time_display():
         if not SimulatedRun and not CameraDisabled:
             camera.switch_mode(capture_config)
             time.sleep(0.1)
-            camera.set_controls({"ScalerCrop": ZoomSize})
+            # No ScalerCrop restore here: ZoomSize may hold a cropped preview-mode
+            # rectangle, and switch_mode already reset the crop to full frame.
         # Restore the saved locale
         locale.setlocale(locale.LC_NUMERIC, saved_locale)
         draw_capture_canvas.config(highlightthickness=0, highlightbackground=default_canvas_bg_color)
@@ -4239,7 +4240,9 @@ def PiCam2_configure():
                                                        transform=Transform(hflip=True))
 
     preview_config = camera.create_preview_configuration({"size": (2028, 1520)}, transform=Transform(hflip=True))
-    vfd_config = camera.create_preview_configuration({"size": (1332, 990)}, transform=Transform(hflip=True))
+    # 2028x1520 selects the full-FOV binned sensor mode; a 1332x990 request can
+    # select the center-cropped 1332x990 mode, making the live view ~1.5x zoomed.
+    vfd_config = camera.create_preview_configuration({"size": (2028, 1520)}, transform=Transform(hflip=True))
     # Camera preview window is not saved in configuration, so always off on start up (we start in capture mode)
     camera.configure(capture_config)
     # WB controls


### PR DESCRIPTION
Since v1.12.21 (cfb15eb), Focus View uses `vfd_config` with a 1332x990 preview size. On recent Raspberry Pi kernels this makes libcamera select the IMX477's native 1332x990 sensor mode, which reads out only the center 2664x1980 of the sensor — so the live view shows ~1.5x less than what is captured.

Worse, on entering Focus View the code saves `ZoomSize = capture_metadata()['ScalerCrop']` (now the cropped rectangle) and re-applies it to the capture configuration on exit. After that, all captures are center-cropped too: a 2028x1520 scan contains only ~1332x990 real pixels upscaled, until the app is restarted.

The trigger is kernel commit raspberrypi/linux@75808a72df ("media: imx477: Support 10 or 12 bit readout for all modes", in builds after 2025-09-23). Before it, the 1332x990 mode was 10-bit only, so libcamera skipped it in favor of the full-FOV 2028x1520 binned mode — which is why this went unnoticed. On current kernels every Pi 4 and Pi 5 user is affected.

Fix (2 lines):
- `vfd_config` size 1332x990 -> 2028x1520, so the full-FOV binned mode is always selected. Focus View fps ceiling drops from 120 to 40, far above what the Tk canvas displays.
- Drop the `ScalerCrop` restore on Focus View exit: `switch_mode` already resets the crop to full frame, and every `ZoomSize` consumer re-reads the value before using it.

Verified: bug reproduced and fix confirmed on Pi 5 kernels 6.12.96 and 6.18.39; no behavior change on 6.12.47 (pre-regression).