### PR TITLE
Fix periodic dark HDR bracket recurring every 8 frames in auto-bracket mode

### DIFF
--- a/ALT-Scann8.py
+++ b/ALT-Scann8.py
@@ -2391,7 +2391,7 @@ def cmd_adjust_merge_in_place():
 
 def adjust_hdr_bracket():
     global recalculate_hdr_exp_list
-    global hdr_best_exp, HdrMinExp
+    global hdr_best_exp, HdrMinExp, HdrMaxExp
     global PreviousCurrentExposure
     global force_adjust_hdr_bracket
     global AutoExpEnabled
@@ -2418,8 +2418,9 @@ def adjust_hdr_bracket():
         PreviousCurrentExposure = aux_current_exposure
         hdr_best_exp = aux_current_exposure
         HdrMinExp = max(hdr_best_exp - int(HdrBracketWidth / 2), HdrMinExp)
+        HdrMaxExp = HdrMinExp + HdrBracketWidth
         hdr_min_exp_value.set(HdrMinExp)
-        hdr_max_exp_value.set(HdrMinExp + HdrBracketWidth)
+        hdr_max_exp_value.set(HdrMaxExp)
         ConfigData["HdrMinExp"] = HdrMinExp
         ConfigData["HdrMaxExp"] = HdrMaxExp
         recalculate_hdr_exp_list = True

--- a/ALT-Scann8.py
+++ b/ALT-Scann8.py
@@ -2430,15 +2430,23 @@ def capture_hdr(mode):
     global recalculate_hdr_exp_list, PreviewModuleValue
     global hw_panel_installed
 
+    bracket_exposure_probed = False
     if HdrBracketAuto and session_frames % hdr_auto_bracket_frames == 0:
         adjust_hdr_bracket()
+        bracket_exposure_probed = True
 
     if recalculate_hdr_exp_list:
         hdr_reinit()
         perform_dry_run = True
         recalculate_hdr_exp_list = False
     else:
-        perform_dry_run = False
+        # adjust_hdr_bracket() runs an auto-exposure probe that leaves the sensor
+        # at the metered exposure, breaking the "first capture equals the previous
+        # frame's last capture" assumption the skip-dry-run path relies on. When the
+        # probe ran we must force a real dry run even if the bracket values are
+        # unchanged, otherwise the frame's first capture (the longest exposure on
+        # reversed frames) is saved before the sensor settles and comes out dark.
+        perform_dry_run = bracket_exposure_probed
 
     images_to_merge.clear()
     # session_frames should be equal to 1 for the first captured frame of the scan session.


### PR DESCRIPTION
**NOTE: This has NOT been tested on device!**

In HDR auto-bracket mode, `adjust_hdr_bracket()` runs every 8 frames: it enables auto exposure, probes the metered exposure, then disables auto exposure again. This leaves the sensor at the metered exposure instead of the exposure the previous frame ended on.

`capture_hdr()` only forced a settling dry run when the probe changed the bracket values. When the metered exposure came back unchanged, the first capture of that frame - the longest exposure on reversed (even) frames, saved as the `.3` bracket - was taken before the sensor settled and came out under-exposed. The result: a corrupt long-exposure bracket recurring on a fixed 8-frame grid, i.e. a periodic brightness dip in the scanned film.

Fixes:
- Force a settling dry run after every auto-bracket probe, not only when bracket values changed
- Update the stored `HdrMaxExp` when the auto-bracket re-meters (previously only the UI spinbox was updated)

Cost: one extra dry run every 8th frame in auto-bracket mode (~26 ms/frame amortized at default exposures).
