### PR TITLE
Keep HDR auto-bracket within the exposure ceiling

### DIFF
--- a/ALT-Scann8.py
+++ b/ALT-Scann8.py
@@ -2391,7 +2391,7 @@ def cmd_adjust_merge_in_place():
 
 def adjust_hdr_bracket():
     global recalculate_hdr_exp_list
-    global hdr_best_exp, HdrMinExp
+    global hdr_best_exp, HdrMinExp, HdrMaxExp
     global PreviousCurrentExposure
     global force_adjust_hdr_bracket
     global AutoExpEnabled
@@ -2418,8 +2418,9 @@ def adjust_hdr_bracket():
         PreviousCurrentExposure = aux_current_exposure
         hdr_best_exp = aux_current_exposure
         HdrMinExp = max(hdr_best_exp - int(HdrBracketWidth / 2), HdrMinExp)
+        HdrMaxExp = HdrMinExp + HdrBracketWidth
         hdr_min_exp_value.set(HdrMinExp)
-        hdr_max_exp_value.set(HdrMinExp + HdrBracketWidth)
+        hdr_max_exp_value.set(HdrMaxExp)
         ConfigData["HdrMinExp"] = HdrMinExp
         ConfigData["HdrMaxExp"] = HdrMaxExp
         recalculate_hdr_exp_list = True

--- a/ALT-Scann8.py
+++ b/ALT-Scann8.py
@@ -2430,15 +2430,23 @@ def capture_hdr(mode):
     global recalculate_hdr_exp_list, PreviewModuleValue
     global hw_panel_installed
 
+    bracket_exposure_probed = False
     if HdrBracketAuto and session_frames % hdr_auto_bracket_frames == 0:
         adjust_hdr_bracket()
+        bracket_exposure_probed = True
 
     if recalculate_hdr_exp_list:
         hdr_reinit()
         perform_dry_run = True
         recalculate_hdr_exp_list = False
     else:
-        perform_dry_run = False
+        # adjust_hdr_bracket() runs an auto-exposure probe that leaves the sensor
+        # at the metered exposure, breaking the "first capture equals the previous
+        # frame's last capture" assumption the skip-dry-run path relies on. When the
+        # probe ran we must force a real dry run even if the bracket values are
+        # unchanged, otherwise the frame's first capture (the longest exposure on
+        # reversed frames) is saved before the sensor settles and comes out dark.
+        perform_dry_run = bracket_exposure_probed
 
     images_to_merge.clear()
     # session_frames should be equal to 1 for the first captured frame of the scan session.

--- a/ALT-Scann8.py
+++ b/ALT-Scann8.py
@@ -2417,8 +2417,8 @@ def adjust_hdr_bracket():
         force_adjust_hdr_bracket = False
         PreviousCurrentExposure = aux_current_exposure
         hdr_best_exp = min(aux_current_exposure, HDR_MAX_EXP)
-        HdrMinExp = min(max(hdr_best_exp - int(HdrBracketWidth / 2), HdrMinExp), HDR_MAX_EXP)
-        HdrMaxExp = min(HdrMinExp + HdrBracketWidth, HDR_MAX_EXP)
+        HdrMinExp = min(max(hdr_best_exp - int(HdrBracketWidth / 2), HdrMinExp), HDR_MAX_EXP - HdrBracketWidth)
+        HdrMaxExp = HdrMinExp + HdrBracketWidth
         hdr_min_exp_value.set(HdrMinExp)
         hdr_max_exp_value.set(HdrMaxExp)
         ConfigData["HdrMinExp"] = HdrMinExp
@@ -2468,7 +2468,7 @@ def capture_hdr(mode):
     is_dng = FileType == 'dng'
     is_png = FileType == 'png'
     for exp in work_list:
-        exp = max(1, exp + HdrBracketShift)  # Apply bracket shift
+        exp = min(max(1, exp + HdrBracketShift), HDR_MAX_EXP)  # Apply bracket shift
         logging.debug("capture_hdr: exp %.2f", exp)
         if perform_dry_run:
             camera.set_controls({"ExposureTime": int(exp * 1000)})

--- a/ALT-Scann8.py
+++ b/ALT-Scann8.py
@@ -2418,7 +2418,7 @@ def adjust_hdr_bracket():
         PreviousCurrentExposure = aux_current_exposure
         hdr_best_exp = aux_current_exposure
         HdrMinExp = max(hdr_best_exp - int(HdrBracketWidth / 2), HdrMinExp)
-        HdrMaxExp = HdrMinExp + HdrBracketWidth
+        HdrMaxExp = min(HdrMinExp + HdrBracketWidth, HDR_MAX_EXP)
         hdr_min_exp_value.set(HdrMinExp)
         hdr_max_exp_value.set(HdrMaxExp)
         ConfigData["HdrMinExp"] = HdrMinExp

--- a/ALT-Scann8.py
+++ b/ALT-Scann8.py
@@ -2416,8 +2416,8 @@ def adjust_hdr_bracket():
         logging.debug(f"Adjusting bracket, prev/cur exp: {PreviousCurrentExposure} -> {aux_current_exposure}")
         force_adjust_hdr_bracket = False
         PreviousCurrentExposure = aux_current_exposure
-        hdr_best_exp = aux_current_exposure
-        HdrMinExp = max(hdr_best_exp - int(HdrBracketWidth / 2), HdrMinExp)
+        hdr_best_exp = min(aux_current_exposure, HDR_MAX_EXP)
+        HdrMinExp = min(max(hdr_best_exp - int(HdrBracketWidth / 2), HdrMinExp), HDR_MAX_EXP)
         HdrMaxExp = min(HdrMinExp + HdrBracketWidth, HDR_MAX_EXP)
         hdr_min_exp_value.set(HdrMinExp)
         hdr_max_exp_value.set(HdrMaxExp)


### PR DESCRIPTION
Follow-up hardening on top of #277 (includes its commits). Keeps the HDR auto-bracket within `HDR_MAX_EXP` in the corner case where the metered exposure approaches the 1000 ms ceiling (near-opaque frames):

- Clamp `hdr_best_exp` and the bracket endpoints to `HDR_MAX_EXP`
- When the ceiling is hit, slide the bracket interval down so `HdrBracketWidth` is preserved (instead of compressing it into duplicate exposures)
- Cap the per-capture exposure after `HdrBracketShift` is applied, so a positive shift cannot push captures past `HDR_MAX_EXP`

Draft: edge-case behavior (metered exposure >= ~950 ms) has not been hardware-tested yet.

Known pre-existing issues in this area, not addressed here: the bracket minimum ratchets upward across re-meters and never comes back down; the HDR exposure list is built at init before saved config is loaded; `HdrBracketShift` is not persisted to the config file.
