### PR TITLE
Fix lossy DNG capture on Pi 5: request unpacked raw format

### DIFF
--- a/ALT-Scann8.py
+++ b/ALT-Scann8.py
@@ -4225,6 +4225,10 @@ def PiCam2_change_resolution():
     camera.configure(capture_config)
     camera.start()
 
+    raw_format = camera.camera_configuration()["raw"]["format"]
+    logging.info(f"Raw stream format granted by camera pipeline: {raw_format}")
+    if "COMP" in raw_format:
+        logging.warning(f"Raw format {raw_format} is lossy-compressed, DNG captures will not be lossless")
     logging.debug(f"Camera resolution set at: {CaptureResolution}")
 
 

--- a/ALT-Scann8.py
+++ b/ALT-Scann8.py
@@ -4220,7 +4220,7 @@ def PiCam2_change_resolution():
     capture_config["main"]["size"] = camera_resolutions.get_image_resolution()
     # capture_config["main"]["format"] = camera_resolutions.get_format()
     capture_config["raw"]["size"] = camera_resolutions.get_sensor_resolution()
-    capture_config["raw"]["format"] = camera_resolutions.get_format()
+    capture_config["raw"]["format"] = camera_resolutions.get_format().replace("_CSI2P", "")
     camera.stop()
     camera.configure(capture_config)
     camera.start()
@@ -4234,8 +4234,11 @@ def PiCam2_configure():
 
     camera.stop()
     capture_config = camera.create_still_configuration(main={"size": camera_resolutions.get_sensor_resolution()},
+                                                       # Request the unpacked raw format: the packed (_CSI2P) request is
+                                                       # not supported by the Pi 5 pipeline, which silently substitutes
+                                                       # the lossy-compressed PISP_COMP1 format, degrading DNG output.
                                                        raw={"size": camera_resolutions.get_sensor_resolution(),
-                                                            "format": camera_resolutions.get_format()},
+                                                            "format": camera_resolutions.get_format().replace("_CSI2P", "")},
                                                        transform=Transform(hflip=True))
 
     preview_config = camera.create_preview_configuration({"size": (2028, 1520)}, transform=Transform(hflip=True))

--- a/camera_resolutions.py
+++ b/camera_resolutions.py
@@ -43,7 +43,12 @@ class CameraResolutions():
                 key = f"{mode['size'][0]}x{mode['size'][1]}"
                 if mode['crop_limits'][0] != 0 or mode['crop_limits'][1] != 0:
                     key = key + ' *'
+                # Recent kernels list each size at several bit depths; keep only the
+                # highest one so lower-depth entries cannot overwrite it
+                if key in self.resolution_dict and self.resolution_dict[key]['bit_depth'] >= mode['bit_depth']:
+                    continue
                 self.resolution_dict[key] = {}
+                self.resolution_dict[key]['bit_depth'] = mode['bit_depth']
                 self.resolution_dict[key]['sensor_resolution'] = mode['size']
                 self.resolution_dict[key]['image_resolution'] = mode['size']
                 if 1024 < mode['size'][0] < aux_width and 768 < mode['size'][1] < aux_height:


### PR DESCRIPTION
The raw stream requests the packed `SRGGB12_CSI2P` format. The Pi 5 (PiSP) pipeline does not support packed CSI2P output and silently substitutes `PISP_COMP1` - a lossy 8-bit/pixel compression - so every DNG on Pi 5 is built from decompressed COMP1 data. Measured on an IMX477 test frame: 901 distinct tonal levels with COMP1 vs 2639 with uncompressed raw (quantization steps up to 8 x 12-bit LSB).

Changes:
- Request the unpacked raw format (strip `_CSI2P`), which both Pi 4 and Pi 5 pipelines honor losslessly. DNG file size is unchanged (the DNG payload is 16-bit either way). Pi 4 was already lossless (packed is supported there); its raw buffer grows from 1.5 to 2 bytes/pixel.
- Log the raw format actually granted by the pipeline at startup/resolution change, and warn if it is a lossy-compressed one.

Draft: verified on Pi 5 (format granted, tonal-level measurement); Pi 4 behavior is per picamera2 documentation, not yet hardware-tested - the new log line makes that easy to confirm.
